### PR TITLE
Various fixes

### DIFF
--- a/src/commands/test.rs
+++ b/src/commands/test.rs
@@ -16,6 +16,7 @@ use aqora_runner::{
 use clap::Args;
 use futures::prelude::*;
 use indicatif::{MultiProgress, ProgressBar};
+use owo_colors::{OwoColorize, Stream as OwoStream};
 use pyo3::prelude::*;
 use pyo3::{exceptions::PyException, Python};
 use std::{
@@ -255,7 +256,12 @@ pub async fn run_submission_tests(
         .await
     {
         Ok(Some(score)) => {
-            pipeline_pb.finish_with_message(format!("Done: {score}"));
+            pipeline_pb.println(format!(
+                "{}: {}",
+                "Score".if_supports_color(OwoStream::Stdout, |text| { text.bold() }),
+                score
+            ));
+            pipeline_pb.finish_and_clear();
             Ok(score)
         }
         Ok(None) => {

--- a/src/commands/test.rs
+++ b/src/commands/test.rs
@@ -154,7 +154,7 @@ pub async fn run_submission_tests(
         data: data_path.canonicalize()?,
     };
 
-    let mut pipeline_pb = ProgressBar::new_spinner().with_message("Running pipeline...");
+    let mut pipeline_pb = ProgressBar::new_spinner().with_message("Starting pipeline...");
     pipeline_pb.enable_steady_tick(std::time::Duration::from_millis(100));
     pipeline_pb = m.add(pipeline_pb);
 
@@ -165,6 +165,8 @@ pub async fn run_submission_tests(
         global.color,
     )
     .await?;
+
+    pipeline_pb.set_message("Importing pipeline..");
 
     let pipeline = match Pipeline::import(&env, &modified_use_case, config) {
         Ok(pipeline) => pipeline,
@@ -177,6 +179,8 @@ pub async fn run_submission_tests(
             ));
         }
     };
+
+    pipeline_pb.set_message("Running tests...");
 
     let (num_inputs, generator) = if tests.is_empty() {
         match pipeline.generator() {

--- a/src/revert_file.rs
+++ b/src/revert_file.rs
@@ -24,7 +24,8 @@ impl RevertFile {
             tmp_prefix,
             path.parent().unwrap_or_else(|| ".".as_ref()),
         )?;
-        std::fs::copy(&path, backed_up.path())?;
+        std::fs::rename(&path, backed_up.path())?;
+        std::fs::copy(backed_up.path(), &path)?;
         let mut files = REVERT_FILES.lock().map_err(|_| {
             std::io::Error::new(std::io::ErrorKind::Other, "Could not lock REVERT_FILES")
         })?;
@@ -43,7 +44,7 @@ impl RevertFile {
     }
 
     fn do_revert(&mut self) -> std::io::Result<()> {
-        std::fs::copy(self.backed_up.path(), &self.path)?;
+        std::fs::rename(self.backed_up.path(), &self.path)?;
         self.reverted = true;
         Ok(())
     }


### PR DESCRIPTION
* Lock python build package version
* Fix build python package name from python build
* Use uv when doing python build
* Always ignore gitignore files when checking for timestamp changes
* Better messages when running aqora test
* Better file revert which preserves file metadata
