### PR TITLE
Handle .pth virualenv scripts correctly

### DIFF
--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -196,13 +196,13 @@ impl AqoraUseCaseConfig {
             .get(test_name)
             .ok_or_else(|| TestConfigError::TestNotFound(test_name.to_string()))?;
         if let Some(data) = test.data.as_ref() {
-            out.data = data.clone();
+            out.data.clone_from(data);
         }
         if let Some(generator) = test.generator.as_ref() {
-            out.generator = generator.clone();
+            out.generator.clone_from(generator);
         }
         if let Some(aggregator) = test.aggregator.as_ref() {
-            out.aggregator = aggregator.clone();
+            out.aggregator.clone_from(aggregator);
         }
         for (layer_name, override_) in test.overrides.iter() {
             if let Some(layer) = out


### PR DESCRIPTION
If there exists a .pth file that's not a valid path, we treat it as a
python script. This was causing errors with modules not being found
