### PR TITLE
feat: add `aqora lab` command

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ venv = [
     "build >=1.2.0, <2.0.0",
     "setuptools >=61.0",
     "ujson >= 5.9.0, <6.0.0",
-    "ipykernel >=6.29.4, <7.0.0",
+    "jupyterlab ~= 4.2.1",
 ]
 
 [project.urls]

--- a/src/commands/lab.rs
+++ b/src/commands/lab.rs
@@ -1,0 +1,23 @@
+use std::ffi::OsString;
+
+use clap::Args;
+use serde::Serialize;
+
+use crate::error::Result;
+
+use super::GlobalArgs;
+
+use crate::commands::python::{python, Python};
+
+#[derive(Args, Debug, Serialize)]
+pub struct Lab {
+    pub jupyter_args: Vec<OsString>,
+}
+
+pub async fn lab(args: Lab, global_args: GlobalArgs) -> Result<()> {
+    let args = Python {
+        module: Some("jupyterlab".into()),
+        python_args: args.jupyter_args,
+    };
+    python(args, global_args).await
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -3,6 +3,7 @@ mod clean;
 mod global_args;
 mod info;
 mod install;
+mod lab;
 mod login;
 mod python;
 mod remove;
@@ -21,6 +22,7 @@ use add::{add, Add};
 use clean::{clean, Clean};
 use info::{info, Info};
 use install::{install, Install};
+use lab::{lab, Lab};
 use login::{login, Login};
 use python::{python, Python};
 use remove::{remove, Remove};
@@ -95,6 +97,7 @@ pub enum Commands {
     Remove(Remove),
     #[command(hide = true)]
     Info(Info),
+    Lab(Lab),
 }
 
 impl Cli {
@@ -112,6 +115,7 @@ impl Cli {
                 Commands::Python(args) => python(args, global).await,
                 Commands::Shell(args) => shell(args, global).await,
                 Commands::Test(args) => test(args, global).await,
+                Commands::Lab(args) => lab(args, global).await,
                 Commands::Upload(args) => upload(args, global).await,
                 Commands::Template(args) => template(args, global).await,
                 Commands::Clean(args) => clean(args, global).await,

--- a/src/commands/shell.rs
+++ b/src/commands/shell.rs
@@ -5,13 +5,16 @@ use crate::{
 use clap::Args;
 use indicatif::ProgressBar;
 use serde::Serialize;
-use std::time::Duration;
+use std::{ffi::OsString, time::Duration};
 
 #[derive(Args, Debug, Serialize)]
 #[command(author, version, about)]
-pub struct Shell;
+pub struct Shell {
+    #[arg(last = true)]
+    pub bash_args: Vec<OsString>,
+}
 
-pub async fn shell(_: Shell, global: GlobalArgs) -> crate::error::Result<()> {
+pub async fn shell(args: Shell, global: GlobalArgs) -> crate::error::Result<()> {
     let _ = read_pyproject(&global.project).await?;
     let progress = ProgressBar::new_spinner();
     progress.set_message("Initializing virtual environment");
@@ -23,11 +26,15 @@ pub async fn shell(_: Shell, global: GlobalArgs) -> crate::error::Result<()> {
         &tempfile,
         format!("source {}", env.activate_path().to_string_lossy()),
     )?;
+
     tokio::process::Command::new("bash")
+        .current_dir(&global.project)
         .arg("--rcfile")
         .arg(tempfile.path())
+        .args(args.bash_args)
         .spawn()?
         .wait()
         .await?;
+
     Ok(())
 }


### PR DESCRIPTION
This PR does three things:

1. enhances a bit the usability of `shell` and `python`,
2. creates a simple `lab` command which is basically like a call `python -m jupyterlab`,
3. supersedes `ipykernel` by `jupyterlab`.

I think the first point is a good net addition, when the two following is just a question of whether we prefer `ipython` to `jupyterlab`??
