### PR TITLE
feat: browserless login

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,6 +115,7 @@ dependencies = [
  "mime",
  "open",
  "owo-colors",
+ "passterm",
  "pyo3",
  "pyo3-asyncio",
  "rand",
@@ -1482,6 +1483,15 @@ dependencies = [
  "redox_syscall 0.4.1",
  "smallvec",
  "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "passterm"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eea7e8981bca32c52230ca5f28b080dd5f28aed618a7bd12b5a382b234cd2b99"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ lazy_static = "1.4"
 mime = "0.3"
 open = "5.0"
 owo-colors = { version = "4.0", features = ["supports-colors"] }
+passterm = "2.0"
 pyo3 = { version = "0.20", features = ["serde"] }
 pyo3-asyncio = { version = "0.20", features = ["attributes", "tokio-runtime"] }
 rand = "0.8"

--- a/src/graphql/login.graphql
+++ b/src/graphql/login.graphql
@@ -1,0 +1,7 @@
+mutation LoginPageUserMutation($input: LoginUserInput!) {
+    loginUser(input: $input) {
+        node {
+            id
+        }
+    }
+}

--- a/src/graphql/oauth2_authorize.graphql
+++ b/src/graphql/oauth2_authorize.graphql
@@ -1,0 +1,7 @@
+mutation Oauth2AuthorizePageMutation($input: Oauth2AuthorizeInput!) {
+    oauth2Authorize(input: $input) {
+        unauthorized
+        clientError
+        redirectUri
+    }
+}

--- a/src/graphql/schema.graphql
+++ b/src/graphql/schema.graphql
@@ -613,7 +613,7 @@ type Mutation {
 	createCompetition(input: CreateCompetitionInput!): CompetitionEdge!
 	updateCompetition(id: ID!, input: UpdateCompetitionInput!): CompetitionEdge!
 	deleteCompetition(id: ID!): ID!
-	createSubmissionVersion(competitionId: ID!, input: UpdateSubmissionInput!, asEntity: ID): ProjectVersionEdge!
+	createSubmissionVersion(competitionId: ID!, input: UpdateSubmissionInput!): ProjectVersionEdge!
 	validateSubmissionVersion(projectVersionId: ID!): ProjectVersionEdge!
 	createTopicForCompetition(competitionId: ID!, input: CreateTopicInput!): TopicEdge!
 	updateTopic(id: ID!, input: UpdateTopicInput!): Topic!


### PR DESCRIPTION
In some cases, a user might not have access to a browser but still need to login through `aqora`.
This PR adds a fallback for those case, using `passterm@2.0` in order to prompt passwords securely.
