### PR TITLE
[Lab] Open vscode

### DIFF
--- a/src/commands/lab.rs
+++ b/src/commands/lab.rs
@@ -1,4 +1,8 @@
-use std::ffi::OsString;
+use std::{
+    ffi::OsString,
+    path::{Path, PathBuf},
+    process::Command,
+};
 
 use clap::Args;
 use serde::Serialize;
@@ -9,15 +13,73 @@ use super::GlobalArgs;
 
 use crate::commands::python::{python, Python};
 
+fn activate_virtual_env(virtual_env_path: &Path) -> Result<(), std::io::Error> {
+    let activate_script = if cfg!(windows) {
+        virtual_env_path.join("Scripts").join("activate.bat")
+    } else {
+        virtual_env_path.join("bin").join("activate")
+    };
+
+    let cmd = if cfg!(windows) {
+        format!("\"{}\"", activate_script.to_str().unwrap())
+    } else {
+        format!("source {}", activate_script.to_str().unwrap())
+    };
+
+    let output = Command::new("sh").arg("-c").arg(&cmd).output()?;
+
+    println!("{}", String::from_utf8_lossy(&output.stdout));
+
+    Ok(())
+}
+
+fn install_extensions() -> Result<(), std::io::Error> {
+    let python_extension = "ms-python.python";
+    Command::new("code")
+        .args(["--install-extension", python_extension, "--force"])
+        .spawn()?
+        .wait()?;
+
+    let jupyter_extension = "ms-toolsai.jupyter";
+    Command::new("code")
+        .args(["--install-extension", jupyter_extension, "--force"])
+        .spawn()?
+        .wait()?;
+
+    Ok(())
+}
+
+fn open_vscode(path: PathBuf) -> Result<(), std::io::Error> {
+    let path_with_submission = format!("{}", path.display());
+    Command::new("code")
+        .args(&[
+            path_with_submission.clone(),
+            "--goto".to_string(),
+            format!("{}/submission/notebook.ipynb:1:1", path_with_submission),
+        ])
+        .spawn()?
+        .wait()?;
+    Ok(())
+}
+
 #[derive(Args, Debug, Serialize)]
 pub struct Lab {
     pub jupyter_args: Vec<OsString>,
+    #[arg(short = 'j', long)]
+    pub jupyter_notebook: bool,
 }
 
 pub async fn lab(args: Lab, global_args: GlobalArgs) -> Result<()> {
-    let args = Python {
-        module: Some("jupyterlab".into()),
-        python_args: args.jupyter_args,
-    };
-    python(args, global_args).await
+    if !args.jupyter_notebook {
+        install_extensions()?;
+        activate_virtual_env(&global_args.project.join(".venv"))?;
+        open_vscode(global_args.project)?;
+        Ok(())
+    } else {
+        let args = Python {
+            module: Some("jupyterlab".into()),
+            python_args: args.jupyter_args,
+        };
+        python(args, global_args).await
+    }
 }

--- a/src/commands/lab.rs
+++ b/src/commands/lab.rs
@@ -1,64 +1,90 @@
-use std::{
-    ffi::OsString,
-    path::{Path, PathBuf},
-    process::Command,
-};
+use std::{ffi::OsString, path::PathBuf, process::Command};
 
 use clap::Args;
 use serde::Serialize;
 
-use crate::error::Result;
+use crate::{
+    dirs::read_pyproject,
+    error::{self, Result},
+};
 
 use super::GlobalArgs;
 
 use crate::commands::python::{python, Python};
 
-fn activate_virtual_env(virtual_env_path: &Path) -> Result<(), std::io::Error> {
-    let activate_script = if cfg!(windows) {
-        virtual_env_path.join("Scripts").join("activate.bat")
-    } else {
-        virtual_env_path.join("bin").join("activate")
-    };
+const VS_CODE_NOT_FOUND_MSG: &str = "VS Code not found. You can install it from https://code.visualstudio.com/ or run `aqora lab -j` to open the lab without VS Code.";
 
-    let cmd = if cfg!(windows) {
-        format!("\"{}\"", activate_script.to_str().unwrap())
-    } else {
-        format!("source {}", activate_script.to_str().unwrap())
-    };
+fn is_vscode_available() -> Result<(), String> {
+    match Command::new("code").arg("--version").output() {
+        Ok(output) => {
+            if output.status.success() {
+                Ok(())
+            } else {
+                Err(VS_CODE_NOT_FOUND_MSG.to_string())
+            }
+        }
+        Err(_) => Err(VS_CODE_NOT_FOUND_MSG.to_string()),
+    }
+}
 
-    let output = Command::new("sh").arg("-c").arg(&cmd).output()?;
+fn install_extensions() -> Result<()> {
+    let extensions = vec!["ms-python.python", "ms-toolsai.jupyter"];
 
-    println!("{}", String::from_utf8_lossy(&output.stdout));
+    for extension in extensions {
+        Command::new("code")
+            .args(["--install-extension", extension, "--force"])
+            .spawn()?
+            .wait()?;
+    }
 
     Ok(())
 }
 
-fn install_extensions() -> Result<(), std::io::Error> {
-    let python_extension = "ms-python.python";
-    Command::new("code")
-        .args(["--install-extension", python_extension, "--force"])
-        .spawn()?
-        .wait()?;
+fn open_vscode(path: PathBuf, module: String, name: String) -> Result<(), std::io::Error> {
+    let notebook_path = format!("{}/{}/{}.ipynb", path.display(), module, name);
+    run_vscode_with_args(&[
+        path.display().to_string(),
+        "--goto".to_string(),
+        notebook_path,
+    ])
+}
 
-    let jupyter_extension = "ms-toolsai.jupyter";
-    Command::new("code")
-        .args(["--install-extension", jupyter_extension, "--force"])
-        .spawn()?
-        .wait()?;
+fn open_vscode_pyproject(path: PathBuf) -> Result<(), std::io::Error> {
+    let toml_path = path.join("pyproject.toml");
+    run_vscode_with_args(&[toml_path.display().to_string()])
+}
 
+fn run_vscode_with_args(args: &[String]) -> Result<(), std::io::Error> {
+    Command::new("code").args(args).spawn()?.wait()?;
     Ok(())
 }
 
-fn open_vscode(path: PathBuf) -> Result<(), std::io::Error> {
-    let path_with_submission = format!("{}", path.display());
-    Command::new("code")
-        .args(&[
-            path_with_submission.clone(),
-            "--goto".to_string(),
-            format!("{}/submission/notebook.ipynb:1:1", path_with_submission),
-        ])
-        .spawn()?
-        .wait()?;
+async fn handle_vscode_integration(global_args: GlobalArgs) -> Result<()> {
+    is_vscode_available().map_err(|err_msg| error::user("vscode not found 😞", &err_msg))?;
+
+    install_extensions()?;
+
+    let project = read_pyproject(&global_args.project).await?;
+    let aqora = project.aqora().ok_or_else(|| {
+        error::user(
+            "No [tool.aqora] section found in pyproject.toml",
+            "Please make sure you are in the correct directory",
+        )
+    })?;
+
+    if let Some(submission) = aqora.as_submission() {
+        if let Some((_key, function_def)) = submission.refs.iter().next() {
+            let path = function_def.path.clone();
+            open_vscode(
+                global_args.project,
+                path.module().to_string(),
+                path.name().to_string(),
+            )?;
+        } else {
+            open_vscode_pyproject(global_args.project)?;
+        }
+    }
+
     Ok(())
 }
 
@@ -71,10 +97,7 @@ pub struct Lab {
 
 pub async fn lab(args: Lab, global_args: GlobalArgs) -> Result<()> {
     if !args.jupyter_notebook {
-        install_extensions()?;
-        activate_virtual_env(&global_args.project.join(".venv"))?;
-        open_vscode(global_args.project)?;
-        Ok(())
+        handle_vscode_integration(global_args).await
     } else {
         let args = Python {
             module: Some("jupyterlab".into()),

--- a/src/dirs.rs
+++ b/src/dirs.rs
@@ -72,6 +72,10 @@ pub fn project_use_case_toml_path(project_dir: impl AsRef<Path>) -> PathBuf {
     project_data_dir(project_dir, USE_CASE_FILENAME)
 }
 
+pub fn vscode_settings_path(project_dir: impl AsRef<Path>) -> PathBuf {
+    project_dir.as_ref().join(".vscode")
+}
+
 pub async fn read_pyproject(project_dir: impl AsRef<Path>) -> Result<PyProject> {
     let path = pyproject_path(&project_dir);
     if !path.exists() {


### PR DESCRIPTION
## Objective

Users who use this CLI essentially use Jupyter Notebook in VSCode. Therefore, it is necessary for these users to be able to open their projects in VSCode without any additional configuration. This pull request provides this capability.

## Implementation

- Executing the command 'code' with specific arguments to:
   - Install Python/Jupyter Notebook extensions.
   - Open the project directory, defaulting to the notebook.ipynb file (assuming each project contains this file).
   - Automatically load Pipenv when executing `aqora lab`.
 - The default behavior opens VSCode by executing `aqora lab`, while users can open Jupyter Notebook by running `aqora lab -j`.

## Demo 
https://github.com/aqora-io/cli/assets/77701490/ad86855a-e96b-4c5d-9e26-9887019f496f


## Checklist
- [x] tested on macos
- [ ] tested on windows
- [x] tested on linux (pop os, ubuntu based distrib) 


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207587035902762