### PR TITLE
fix(cli): loaded python kernel

### DIFF
--- a/src/commands/lab.rs
+++ b/src/commands/lab.rs
@@ -12,7 +12,7 @@ use serde_json::json;
 use tokio::process::Command;
 
 use crate::{
-    dirs::{init_venv, vscode_settings_path},
+    dirs::{init_venv, project_vscode_dir, vscode_settings_path},
     error::{self, Result},
     process::run_command,
 };
@@ -79,21 +79,18 @@ async fn open_vscode(path: PathBuf, pb: &ProgressBar) -> Result<(), std::io::Err
 }
 
 fn create_vscode_settings(project_dir: &Path, env: &PyEnv) -> Result<()> {
-    let vscode_dir = vscode_settings_path(project_dir);
+    let vscode_dir = project_vscode_dir(project_dir);
 
     if vscode_dir.exists() {
         Ok(())
     } else {
         fs::create_dir_all(&vscode_dir)?;
-
-        let settings_path = vscode_dir.join("settings.json");
-        let interpreter_path = env.python_path().to_string_lossy().to_string();
-
+        let interpreter_path = env.activate_path().to_string_lossy().to_string();
         let settings = json!({
             "python.defaultInterpreterPath": interpreter_path
         });
 
-        fs::write(settings_path, settings.to_string())?;
+        fs::write(vscode_settings_path(project_dir), settings.to_string())?;
         Ok(())
     }
 }

--- a/src/dirs.rs
+++ b/src/dirs.rs
@@ -17,9 +17,11 @@ use std::{
 const AQORA_DIRNAME: &str = ".aqora";
 const DATA_DIRNAME: &str = "data";
 const VENV_DIRNAME: &str = ".venv";
+const VSCODE_DIRNAME: &str = ".vscode";
 const LAST_RUN_DIRNAME: &str = "last_run";
 const PYPROJECT_FILENAME: &str = "pyproject.toml";
 const USE_CASE_FILENAME: &str = "use_case.toml";
+const VSCODE_SETTINGS_FILENAME: &str = "settings.json";
 
 pub async fn config_dir() -> Result<PathBuf> {
     let mut path = dirs::data_dir().or_else(dirs::config_dir).ok_or_else(|| {
@@ -72,8 +74,12 @@ pub fn project_use_case_toml_path(project_dir: impl AsRef<Path>) -> PathBuf {
     project_data_dir(project_dir, USE_CASE_FILENAME)
 }
 
+pub fn project_vscode_dir(project_dir: impl AsRef<Path>) -> PathBuf {
+    project_dir.as_ref().join(VSCODE_DIRNAME)
+}
+
 pub fn vscode_settings_path(project_dir: impl AsRef<Path>) -> PathBuf {
-    project_dir.as_ref().join(".vscode")
+    project_vscode_dir(project_dir).join(VSCODE_SETTINGS_FILENAME)
 }
 
 pub async fn read_pyproject(project_dir: impl AsRef<Path>) -> Result<PyProject> {


### PR DESCRIPTION
## Objective 

Fix the loaded environment. Currently, we load the Python binary instead of loading the 'active' bin of the '.venv'.