### PR TITLE
feat: Add ability to configure python

### DIFF
--- a/runner/src/python.rs
+++ b/runner/src/python.rs
@@ -146,6 +146,7 @@ impl PyEnv {
         uv_path: impl AsRef<Path>,
         venv_path: impl AsRef<Path>,
         cache_path: Option<impl AsRef<Path>>,
+        python: Option<impl AsRef<str>>,
         color: ColorChoice,
     ) -> Result<Self, EnvError> {
         let cache_path = if let Some(cache_path) = cache_path {
@@ -162,7 +163,7 @@ impl PyEnv {
             None
         };
         let venv_path = venv_path.as_ref();
-        Self::ensure_venv(&uv_path, &venv_path, cache_path.as_ref(), color).await?;
+        Self::ensure_venv(&uv_path, &venv_path, cache_path.as_ref(), python, color).await?;
         let venv_path = venv_path
             .canonicalize()
             .map_err(|err| EnvError::Io(venv_path.to_path_buf(), err))?;
@@ -189,6 +190,7 @@ impl PyEnv {
         uv_path: impl AsRef<Path>,
         venv_path: impl AsRef<Path>,
         cache_path: Option<impl AsRef<Path>>,
+        python: Option<impl AsRef<str>>,
         color: ColorChoice,
     ) -> Result<(), EnvError> {
         let uv_path = uv_path.as_ref();
@@ -197,7 +199,12 @@ impl PyEnv {
             let mut cmd = Command::new(uv_path);
             cmd.arg("venv")
                 .arg("--python")
-                .arg(PYTHON_VERSION.as_str())
+                .arg(
+                    python
+                        .as_ref()
+                        .map(|p| p.as_ref())
+                        .unwrap_or_else(|| PYTHON_VERSION.as_str()),
+                )
                 .arg(venv_path.as_ref());
             if let Some(cache_path) = cache_path.as_ref() {
                 cmd.arg("--cache-dir").arg(cache_path.as_ref());

--- a/runner/src/python.rs
+++ b/runner/src/python.rs
@@ -121,9 +121,9 @@ impl PipPackage {
 }
 
 #[cfg(not(target_os = "windows"))]
-const BIN_PATH: &str = "bin";
+pub const BIN_PATH: &str = "bin";
 #[cfg(target_os = "windows")]
-const BIN_PATH: &str = "Scripts";
+pub const BIN_PATH: &str = "Scripts";
 
 #[derive(Debug, Clone)]
 pub struct PyEnv {

--- a/src/cfg_file.rs
+++ b/src/cfg_file.rs
@@ -1,0 +1,31 @@
+use tokio::io::{self, AsyncBufRead, AsyncBufReadExt};
+
+fn parse_cfg_line(line: &str) -> Option<(&str, &str)> {
+    let trimmed = line.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    if let Some(index) = trimmed.find('=') {
+        let key = trimmed[..index].trim();
+        let value = trimmed[index + 1..].trim();
+        Some((key, value))
+    } else {
+        None
+    }
+}
+
+pub async fn read_cfg_file_key(
+    input: impl AsyncBufRead + Unpin,
+    key: impl AsRef<str>,
+) -> io::Result<Option<String>> {
+    let search = key.as_ref();
+    let mut lines = input.lines();
+    let mut value = None;
+    while let Some(line) = lines.next_line().await? {
+        match parse_cfg_line(&line) {
+            Some((key, new_value)) if key == search => value = Some(new_value.to_string()),
+            _ => (),
+        }
+    }
+    Ok(value)
+}

--- a/src/commands/add.rs
+++ b/src/commands/add.rs
@@ -180,7 +180,14 @@ pub async fn add(args: Add, global: GlobalArgs) -> Result<()> {
     let progress = ProgressBar::new_spinner();
     progress.set_message("Initializing virtual environment");
     progress.enable_steady_tick(Duration::from_millis(100));
-    let env = init_venv(&global.project, global.uv.as_ref(), &progress, global.color).await?;
+    let env = init_venv(
+        &global.project,
+        global.uv.as_ref(),
+        global.python.as_ref(),
+        &progress,
+        global.color,
+    )
+    .await?;
     let project_file = RevertFile::save(pyproject_path(&global.project))?;
     let mut toml = fs::read_to_string(&project_file)
         .await?

--- a/src/commands/global_args.rs
+++ b/src/commands/global_args.rs
@@ -29,6 +29,8 @@ pub struct GlobalArgs {
     pub uv: Option<PathBuf>,
     #[arg(long, global = true)]
     pub python: Option<String>,
+    #[arg(long, global = true, default_value = "false")]
+    pub ignore_venv_aqora: bool,
     #[arg(long, default_value_t = *DEFAULT_PARALLELISM, global = true)]
     pub max_concurrency: usize,
     #[arg(long, default_value_t = ColorChoice::Auto, global = true)]

--- a/src/commands/global_args.rs
+++ b/src/commands/global_args.rs
@@ -27,6 +27,8 @@ pub struct GlobalArgs {
     pub project: PathBuf,
     #[arg(long, global = true)]
     pub uv: Option<PathBuf>,
+    #[arg(long, default_value = ".", global = true)]
+    pub python: Option<String>,
     #[arg(long, default_value_t = *DEFAULT_PARALLELISM, global = true)]
     pub max_concurrency: usize,
     #[arg(long, default_value_t = ColorChoice::Auto, global = true)]

--- a/src/commands/global_args.rs
+++ b/src/commands/global_args.rs
@@ -27,7 +27,7 @@ pub struct GlobalArgs {
     pub project: PathBuf,
     #[arg(long, global = true)]
     pub uv: Option<PathBuf>,
-    #[arg(long, default_value = ".", global = true)]
+    #[arg(long, global = true)]
     pub python: Option<String>,
     #[arg(long, default_value_t = *DEFAULT_PARALLELISM, global = true)]
     pub max_concurrency: usize,

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -112,7 +112,14 @@ pub async fn install_submission(
         })
         .transpose()?;
 
-    let env = init_venv(&global.project, global.uv.as_ref(), &venv_pb, global.color).await?;
+    let env = init_venv(
+        &global.project,
+        global.uv.as_ref(),
+        global.python.as_ref(),
+        &venv_pb,
+        global.color,
+    )
+    .await?;
 
     let use_case_package_name = competition.use_case.name.clone();
     let use_case_res = competition.use_case.latest.ok_or_else(|| {
@@ -244,7 +251,14 @@ pub async fn install_use_case(args: Install, global: GlobalArgs) -> Result<()> {
     pb.enable_steady_tick(std::time::Duration::from_millis(100));
     pb = m.add(pb);
 
-    let env = init_venv(&global.project, global.uv.as_ref(), &pb, global.color).await?;
+    let env = init_venv(
+        &global.project,
+        global.uv.as_ref(),
+        global.python.as_ref(),
+        &pb,
+        global.color,
+    )
+    .await?;
 
     pip_install(
         &env,

--- a/src/commands/lab.rs
+++ b/src/commands/lab.rs
@@ -124,6 +124,7 @@ pub async fn lab(args: Lab, global_args: GlobalArgs) -> Result<()> {
     let env = init_venv(
         &global_args.project,
         global_args.uv.as_ref(),
+        global_args.python.as_ref(),
         &pb,
         global_args.color,
     )

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -40,9 +40,9 @@ use clap::{CommandFactory, Parser, Subcommand};
 #[command(author, version = version(), about)]
 pub struct Cli {
     #[command(flatten)]
-    global: GlobalArgs,
+    pub global: GlobalArgs,
     #[command(subcommand)]
-    commands: Commands,
+    pub commands: Commands,
 }
 
 #[derive(Subcommand, Debug, Serialize)]

--- a/src/commands/python.rs
+++ b/src/commands/python.rs
@@ -21,7 +21,14 @@ pub async fn python(args: Python, global: GlobalArgs) -> crate::error::Result<()
     let progress = ProgressBar::new_spinner();
     progress.set_message("Initializing virtual environment");
     progress.enable_steady_tick(Duration::from_millis(100));
-    let env = init_venv(&global.project, global.uv.as_ref(), &progress, global.color).await?;
+    let env = init_venv(
+        &global.project,
+        global.uv.as_ref(),
+        global.python.as_ref(),
+        &progress,
+        global.color,
+    )
+    .await?;
     progress.finish_and_clear();
     let mut cmd = env.python_cmd();
     cmd.current_dir(&global.project);

--- a/src/commands/remove.rs
+++ b/src/commands/remove.rs
@@ -77,7 +77,14 @@ pub async fn remove(args: Remove, global: GlobalArgs) -> Result<()> {
     let progress = ProgressBar::new_spinner();
     progress.set_message("Initializing virtual environment");
     progress.enable_steady_tick(Duration::from_millis(100));
-    let env = init_venv(&global.project, global.uv.as_ref(), &progress, global.color).await?;
+    let env = init_venv(
+        &global.project,
+        global.uv.as_ref(),
+        global.python.as_ref(),
+        &progress,
+        global.color,
+    )
+    .await?;
     let project_file = RevertFile::save(pyproject_path(&global.project))?;
     let mut toml = fs::read_to_string(&project_file)
         .await?

--- a/src/commands/shell.rs
+++ b/src/commands/shell.rs
@@ -19,7 +19,14 @@ pub async fn shell(args: Shell, global: GlobalArgs) -> crate::error::Result<()> 
     let progress = ProgressBar::new_spinner();
     progress.set_message("Initializing virtual environment");
     progress.enable_steady_tick(Duration::from_millis(100));
-    let env = init_venv(&global.project, global.uv.as_ref(), &progress, global.color).await?;
+    let env = init_venv(
+        &global.project,
+        global.uv.as_ref(),
+        global.python.as_ref(),
+        &progress,
+        global.color,
+    )
+    .await?;
     progress.finish_and_clear();
     let tempfile = tempfile::NamedTempFile::new()?;
     std::fs::write(

--- a/src/commands/test.rs
+++ b/src/commands/test.rs
@@ -294,6 +294,7 @@ pub async fn run_submission_tests(
     let env = init_venv(
         &global.project,
         global.uv.as_ref(),
+        global.python.as_ref(),
         &pipeline_pb,
         global.color,
     )
@@ -625,7 +626,14 @@ async fn test_use_case(args: Test, global: GlobalArgs, project: PyProject) -> Re
         m.add(ProgressBar::new_spinner().with_message("Setting up virtual environment..."));
     venv_pb.enable_steady_tick(std::time::Duration::from_millis(100));
 
-    let env = init_venv(&global.project, global.uv.as_ref(), &venv_pb, global.color).await?;
+    let env = init_venv(
+        &global.project,
+        global.uv.as_ref(),
+        global.python.as_ref(),
+        &venv_pb,
+        global.color,
+    )
+    .await?;
 
     let mut use_case = use_case.clone();
     convert_use_case_notebooks(&env, &mut use_case).await?;

--- a/src/commands/upload.rs
+++ b/src/commands/upload.rs
@@ -408,7 +408,14 @@ pub async fn upload_use_case(
     venv_pb.enable_steady_tick(std::time::Duration::from_millis(100));
     venv_pb = m.add(venv_pb);
 
-    let env = init_venv(&global.project, global.uv.as_ref(), &venv_pb, global.color).await?;
+    let env = init_venv(
+        &global.project,
+        global.uv.as_ref(),
+        global.python.as_ref(),
+        &venv_pb,
+        global.color,
+    )
+    .await?;
 
     venv_pb.finish_with_message("Virtual environment initialized");
 
@@ -688,7 +695,14 @@ pub async fn upload_submission(
     venv_pb.enable_steady_tick(std::time::Duration::from_millis(100));
     venv_pb = m.add(venv_pb);
 
-    let env = init_venv(&global.project, global.uv.as_ref(), &venv_pb, global.color).await?;
+    let env = init_venv(
+        &global.project,
+        global.uv.as_ref(),
+        global.python.as_ref(),
+        &venv_pb,
+        global.color,
+    )
+    .await?;
 
     venv_pb.finish_with_message("Virtual environment initialized");
 
@@ -1010,6 +1024,9 @@ Do you want to run the tests now?"#,
         .await?;
 
     validate_pb.finish_with_message("Done!");
+
+    tracing::warn!("Dropping {}", tempdir.path().display());
+    std::mem::forget(tempdir);
 
     Ok(())
 }

--- a/src/dirs.rs
+++ b/src/dirs.rs
@@ -225,13 +225,14 @@ async fn ensure_uv(
 pub async fn init_venv(
     project_dir: impl AsRef<Path>,
     uv_path: Option<impl AsRef<Path>>,
+    python: Option<impl AsRef<str>>,
     pb: &ProgressBar,
     color: ColorChoice,
 ) -> Result<PyEnv> {
     pb.set_message("Initializing the Python environment...");
     let uv_path = ensure_uv(uv_path, pb, color).await?;
     let venv_dir = project_venv_dir(&project_dir);
-    let env = PyEnv::init(uv_path, &venv_dir, None::<PathBuf>, color.pip())
+    let env = PyEnv::init(uv_path, &venv_dir, None::<PathBuf>, python, color.pip())
         .await
         .map_err(|e| {
             error::user(

--- a/src/dirs.rs
+++ b/src/dirs.rs
@@ -6,7 +6,7 @@ use crate::{
     process::run_command,
 };
 use aqora_config::PyProject;
-use aqora_runner::python::PyEnv;
+use aqora_runner::python::{PyEnv, BIN_PATH};
 use clap::ColorChoice;
 use indicatif::ProgressBar;
 use serde::{Deserialize, Serialize};
@@ -51,6 +51,10 @@ pub fn project_config_dir(project_dir: impl AsRef<Path>) -> PathBuf {
 
 pub fn project_venv_dir(project_dir: impl AsRef<Path>) -> PathBuf {
     project_dir.as_ref().join(VENV_DIRNAME)
+}
+
+pub fn project_bin_dir(project_dir: impl AsRef<Path>) -> PathBuf {
+    project_venv_dir(project_dir).join(BIN_PATH)
 }
 
 pub fn project_last_run_dir(project_dir: impl AsRef<Path>) -> PathBuf {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+mod cfg_file;
 mod colors;
 mod commands;
 mod compress;

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,5 +3,5 @@ use std::process::ExitCode;
 fn main() -> ExitCode {
     let _sentry = aqora_cli::sentry::setup();
     pyo3::prepare_freethreaded_python();
-    aqora_cli::run(std::env::args()).into()
+    aqora_cli::run(std::env::args_os()).into()
 }

--- a/src/run.rs
+++ b/src/run.rs
@@ -1,18 +1,42 @@
 use std::ffi::OsString;
+use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 
 use clap::Parser;
 
 use crate::commands::Cli;
+use crate::dirs::project_bin_dir;
 
 static TOKIO: OnceLock<tokio::runtime::Runtime> = OnceLock::new();
+
+fn find_venv_aqora(name: impl AsRef<Path>, cli: &Cli) -> Option<PathBuf> {
+    if cli.global.ignore_venv_aqora {
+        return None;
+    }
+    let name = name.as_ref().file_name()?;
+    let path = project_bin_dir(&cli.global.project).join(name);
+    if path.exists() {
+        Some(path)
+    } else {
+        None
+    }
+}
 
 pub fn run<I, T>(args: I) -> u8
 where
     I: IntoIterator<Item = T>,
     T: Into<OsString> + Clone,
 {
-    let cli = Cli::parse_from(args);
+    let mut args = args.into_iter().map(|s| s.into()).collect::<Vec<_>>();
+    let cli = Cli::parse_from(args.clone());
+    let name = args.remove(0);
+    if let Some(venv_aqora) = find_venv_aqora(name, &cli) {
+        let status = std::process::Command::new(venv_aqora)
+            .args(args)
+            .status()
+            .unwrap();
+        return status.code().unwrap_or(1).try_into().unwrap_or(1);
+    }
     let tokio = TOKIO.get_or_init(|| {
         tokio::runtime::Builder::new_multi_thread()
             .enable_all()

--- a/src/run.rs
+++ b/src/run.rs
@@ -31,6 +31,7 @@ where
     let cli = Cli::parse_from(args.clone());
     let name = args.remove(0);
     if let Some(venv_aqora) = find_venv_aqora(name, &cli) {
+        args.push("--ignore-venv-aqora".into());
         let status = std::process::Command::new(venv_aqora)
             .args(args)
             .status()


### PR DESCRIPTION
This adds the ability to select the python version for the virtual environment created by the CLI. It emits a warning if the python version for the virtual environment is already configured and a new one is passed in. It also selects the aqora bin inside of the virtual environment if its available.