### PR TITLE
fix: build for aarch64

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        target: [x86_64, x86] # aarch64, armv7, s390x, ppc64le
+        target: [x86_64, x86, aarch64] # armv7, s390x, ppc64le
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
@@ -35,6 +35,9 @@ jobs:
           sccache: 'true'
           manylinux: auto
           docker-options: -e SENTRY_DSN
+        env:
+          # Workaround ring 0.17 build issue
+          CFLAGS_aarch64_unknown_linux_gnu: '-D__ARM_ARCH=8'
       - name: Upload wheels
         uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
## Objective

We encountered an issue when trying to use the CLI on the Linux aarch64 platform. This is because we have not built a package for this architecture. This PR will implement a build for this platform and introduce the CLI for this architecture.

## Implementation

We are supporting the build for this version in the `cd.yml` file, and addressing the `ring 0.17` error for the aarch64 platform.