### PR TITLE
fix: Use custom template for python exporter

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: "3.10"
+          cache: "pip"
+      - run: pip install uv
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal


### PR DESCRIPTION
For some reason, windows has trouble finding the template file in the virtual environment we set up through python, so I figured it would just be easier to pass it directly. That also gives us control to edit it more manually in the future