### PR TITLE
feat: improvements to keep aqora-cli up to date

### DIFF
--- a/src/commands/info.rs
+++ b/src/commands/info.rs
@@ -10,7 +10,7 @@ use graphql_client::GraphQLQuery;
 use indicatif::ProgressBar;
 use pyo3::Python;
 use serde::Serialize;
-use std::env::args;
+use std::env::{args, current_exe};
 use which::which;
 
 #[derive(GraphQLQuery)]
@@ -41,10 +41,14 @@ pub async fn info(_: Info, global: GlobalArgs) -> Result<()> {
             .and_then(|prefix| prefix.extract::<String>())
     });
     let command = {
-        let command = args().next().unwrap_or_else(|| "aqora".to_string());
-        which(&command)
-            .map(|c| c.display().to_string())
-            .unwrap_or(command)
+        if let Ok(path) = current_exe() {
+            path.display().to_string()
+        } else {
+            let command = args().next().unwrap_or_else(|| "aqora".to_string());
+            which(&command)
+                .map(|c| c.display().to_string())
+                .unwrap_or(command)
+        }
     };
     let uv_path = locate_uv(global.uv.as_ref()).await;
     let uv_version = {

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -207,6 +207,7 @@ pub async fn install_submission(
         let install_fut = pip_install(
             &env,
             [
+                PipPackage::pypi("aqora-cli[venv]"),
                 PipPackage::tar(use_case_package_name, use_case_package_url.to_string()),
                 PipPackage::editable(&global.project),
             ],

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -20,3 +20,10 @@ pub fn manifest_name() -> &'static str {
         .map(|project| project.name.as_str())
         .unwrap()
 }
+
+pub fn parse_aqora_version(version_output: &str) -> Option<Version> {
+    version_output
+        .split_whitespace()
+        .nth(1)
+        .and_then(|v| v.parse().ok())
+}


### PR DESCRIPTION
- **feat: add aqora-cli to install command as dep**
- **feat: use aqora-cli in venv only if version is greater**

Does a few things:

- Adds `aqora-cli[venv]` to the `aqora install` command, so that running `aqora install --upgrade` will upgrade the `aqora-cli` inside the venv
- Uses `current_exe` to add better info to `aqora info` because `which` after initializing the venv includes venv/bin in the path
- Only uses the `aqora-cli` in the venv if the version is greater than the currently used `aqora-cli`
