### PR TITLE
fix: deserialize issues for serde_json arbitrary precision

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,10 +74,7 @@ sentry = { version = "0.32", default-features = false, features = [
   "tracing",
 ] }
 serde = { version = "1.0", features = ["derive"] }
-serde_json = { version = "1.0", features = [
-  "preserve_order",
-  "arbitrary_precision",
-] }
+serde_json = { version = "1.0", features = ["preserve_order"] }
 supports-color = "3.0"
 tempfile = "3.9"
 thiserror = "1.0"


### PR DESCRIPTION
arbitrary precision uses some internal structs for handling arbitrary
precision which causes problems on deserialize (specifically here for
the platform, but I also had similar issues when doing the data-utils).
This really doesn't affect anything here other than potentially tests
configuration for use-cases that specify an "expecting" value, but
seeing as those test configurations are rarely used and can be tweaked
in any case, I don't see this as being a breaking change
