### PR TITLE
fix: use a custom body for wasm targets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -208,6 +208,7 @@ dependencies = [
  "graphql_client",
  "http 1.3.1",
  "http-body 1.0.1",
+ "http-body-util",
  "pin-project-lite",
  "reqwest",
  "serde",

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -17,12 +17,10 @@ default = [
   "threaded",
   "tokio-time",
   "crc32fast",
-  "request-stream",
-  "response-stream",
 ]
 threaded = []
 ws = ["graphql-ws-client"]
-trace = ["tracing", "tower-http", "tower-http/trace", "serde", "serde/derive"]
+trace = ["tracing", "tower-http", "tower-http/trace", "serde/derive"]
 s3 = []
 retry = ["tower/retry"]
 checksum = []
@@ -34,8 +32,6 @@ rustls-tls-webpki-roots = [
   "tokio-tungstenite/rustls-tls-webpki-roots",
 ]
 tokio-time = ["tokio/time"]
-request-stream = ["reqwest/stream"]
-response-stream = ["reqwest/stream", "tokio-util"]
 
 default-wasm = ["wasm-time"]
 wasm = [
@@ -47,7 +43,10 @@ wasm = [
 wasm-time = ["wasm"]
 
 [dependencies]
-reqwest = { version = "0.12", default-features = false, features = ["json"] }
+reqwest = { version = "0.12", default-features = false, features = [
+  "json",
+  "stream",
+] }
 graphql_client = "0.14"
 url = "2.5"
 thiserror = "1.0"
@@ -60,7 +59,7 @@ bytes = "1.10"
 crc32fast = { version = "1.4", optional = true }
 base64 = "0.22"
 tokio = "1.45"
-tokio-util = { version = "0.7", optional = true, features = ["io"] }
+tokio-util = { version = "0.7", features = ["io"] }
 
 graphql-ws-client = { version = "0.11", features = [
   "client-graphql-client",
@@ -74,7 +73,8 @@ tower = "0.5.2"
 tower-http = { version = "0.6.6", optional = true }
 http = "1.3.1"
 http-body = "1.0.1"
-serde = { version = "1.0", optional = true }
+serde = "1.0"
+http-body-util = "0.1.3"
 
 [dev-dependencies]
 aws-config = "1.1"

--- a/client/src/async_util.rs
+++ b/client/src/async_util.rs
@@ -5,6 +5,7 @@ mod async_impl {
     pub trait MaybeSync {}
     impl<T: ?Sized> MaybeSync for T {}
     pub type MaybeLocalBoxFuture<'a, T> = futures::future::LocalBoxFuture<'a, T>;
+    pub type MaybeLocalBoxStream<'a, T> = futures::stream::LocalBoxStream<'a, T>;
 }
 
 #[cfg(feature = "threaded")]
@@ -12,6 +13,7 @@ mod async_impl {
     pub use std::marker::Send as MaybeSend;
     pub use std::marker::Sync as MaybeSync;
     pub type MaybeLocalBoxFuture<'a, T> = futures::future::BoxFuture<'a, T>;
+    pub type MaybeLocalBoxStream<'a, T> = futures::stream::BoxStream<'a, T>;
 }
 
 pub use async_impl::*;
@@ -26,3 +28,14 @@ pub trait MaybeLocalFutureExt: std::future::Future {
 }
 
 impl<T> MaybeLocalFutureExt for T where T: std::future::Future {}
+
+pub trait MaybeLocalStreamExt: futures::stream::Stream {
+    fn boxed_maybe_local<'a>(self) -> MaybeLocalBoxStream<'a, Self::Item>
+    where
+        Self: Sized + MaybeSend + 'a,
+    {
+        Box::pin(self)
+    }
+}
+
+impl<T> MaybeLocalStreamExt for T where T: futures::stream::Stream {}

--- a/client/src/http.rs
+++ b/client/src/http.rs
@@ -1,12 +1,235 @@
+use std::io;
+use std::pin::Pin;
 use std::sync::Arc;
-use std::task::{Context, Poll};
+use std::task::{ready, Context, Poll};
 
+use bytes::Bytes;
 use futures::future::TryFutureExt;
+use futures::stream::{Stream, TryStreamExt};
+use http_body::Body as HttpBody;
 use tower::{Layer, Service};
 
-use crate::async_util::{MaybeLocalBoxFuture, MaybeLocalFutureExt};
-use crate::error::MiddlewareError;
+use crate::async_util::{
+    MaybeLocalBoxFuture, MaybeLocalBoxStream, MaybeLocalFutureExt, MaybeLocalStreamExt, MaybeSend,
+};
+use crate::error::{BoxError, MiddlewareError};
 use crate::tower_util::{ArcLayer, BoxService};
+
+pub use http_body::SizeHint;
+
+pub enum Body {
+    Bytes(Bytes),
+    Stream {
+        size_hint: http_body::SizeHint,
+        stream: MaybeLocalBoxStream<'static, Result<Bytes, BoxError>>,
+    },
+}
+
+impl Default for Body {
+    fn default() -> Self {
+        Body::Bytes(Bytes::new())
+    }
+}
+
+impl Body {
+    pub fn as_bytes(&self) -> Option<&Bytes> {
+        match self {
+            Body::Bytes(bytes) => Some(bytes),
+            Body::Stream { .. } => None,
+        }
+    }
+
+    pub fn content_length(&self) -> Option<usize> {
+        match self {
+            Body::Bytes(bytes) => Some(bytes.len()),
+            Body::Stream { size_hint, .. } => size_hint.exact().map(|size| size as usize),
+        }
+    }
+
+    pub async fn bytes(self) -> Result<Bytes, BoxError> {
+        Ok(http_body_util::BodyExt::collect(self).await?.to_bytes())
+    }
+
+    pub async fn json<T: serde::de::DeserializeOwned>(self) -> crate::error::Result<T> {
+        let bytes = self
+            .bytes()
+            .await
+            .map_err(crate::error::Error::Middleware)?;
+        Ok(serde_json::from_slice(&bytes)?)
+    }
+
+    pub fn wrap<B>(body: B) -> Body
+    where
+        B: HttpBody + MaybeSend + 'static,
+        B::Data: Into<Bytes>,
+        B::Error: Into<BoxError>,
+    {
+        Body::Stream {
+            size_hint: body.size_hint(),
+            stream: http_body_util::BodyDataStream::new(body)
+                .map_ok(|bytes| bytes.into())
+                .map_err(|err| err.into())
+                .boxed_maybe_local(),
+        }
+    }
+
+    pub fn into_async_read(
+        self,
+    ) -> tokio_util::io::StreamReader<MaybeLocalBoxStream<'static, io::Result<Bytes>>, Bytes> {
+        tokio_util::io::StreamReader::new(match self {
+            Body::Bytes(bytes) => futures::stream::iter(vec![Ok(bytes)]).boxed_maybe_local(),
+            Body::Stream { stream, .. } => stream
+                .map_err(|err| io::Error::new(io::ErrorKind::Other, err.to_string()))
+                .boxed_maybe_local(),
+        })
+    }
+
+    pub fn try_clone(&self) -> Option<Self> {
+        match self {
+            Self::Bytes(bytes) => Some(Self::Bytes(bytes.clone())),
+            Self::Stream { .. } => None,
+        }
+    }
+}
+
+impl From<String> for Body {
+    fn from(s: String) -> Self {
+        Body::Bytes(Bytes::from(s))
+    }
+}
+
+impl From<Vec<u8>> for Body {
+    fn from(v: Vec<u8>) -> Self {
+        Body::Bytes(Bytes::from(v))
+    }
+}
+
+impl From<Bytes> for Body {
+    fn from(bytes: Bytes) -> Self {
+        Body::Bytes(bytes)
+    }
+}
+
+impl HttpBody for Body {
+    type Data = Bytes;
+    type Error = BoxError;
+
+    fn poll_frame(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context,
+    ) -> Poll<Option<Result<http_body::Frame<Self::Data>, Self::Error>>> {
+        match *self {
+            Body::Bytes(ref mut bytes) => {
+                let out = bytes.split_off(0);
+                if out.is_empty() {
+                    Poll::Ready(None)
+                } else {
+                    Poll::Ready(Some(Ok(http_body::Frame::data(out))))
+                }
+            }
+            Body::Stream { ref mut stream, .. } => Poll::Ready(
+                ready!(Pin::new(stream).poll_next(cx)).map(|opt| opt.map(http_body::Frame::data)),
+            ),
+        }
+    }
+
+    fn size_hint(&self) -> http_body::SizeHint {
+        match *self {
+            Body::Bytes(ref bytes) => http_body::SizeHint::with_exact(bytes.len() as u64),
+            Body::Stream { ref size_hint, .. } => size_hint.clone(),
+        }
+    }
+
+    fn is_end_stream(&self) -> bool {
+        match *self {
+            Body::Bytes(ref bytes) => bytes.is_empty(),
+            Body::Stream { .. } => false,
+        }
+    }
+}
+
+impl TryFrom<reqwest::Body> for Body {
+    type Error = MiddlewareError;
+    fn try_from(body: reqwest::Body) -> Result<Self, MiddlewareError> {
+        if let Some(bytes) = body.as_bytes() {
+            Ok(Self::Bytes(Bytes::copy_from_slice(bytes)))
+        } else {
+            #[cfg(target_arch = "wasm32")]
+            {
+                Err(MiddlewareError::StreamsNotSupported)
+            }
+            #[cfg(not(target_arch = "wasm32"))]
+            {
+                Ok(Body::Stream {
+                    size_hint: body.size_hint(),
+                    stream: http_body_util::BodyDataStream::new(body)
+                        .map_err(|err| err.into())
+                        .boxed_maybe_local(),
+                })
+            }
+        }
+    }
+}
+
+impl TryFrom<Body> for reqwest::Body {
+    type Error = MiddlewareError;
+    fn try_from(body: Body) -> Result<Self, MiddlewareError> {
+        match body {
+            Body::Bytes(bytes) => Ok(reqwest::Body::from(bytes)),
+            #[cfg(any(target_arch = "wasm32", not(feature = "threaded"),))]
+            Body::Stream { .. } => Err(MiddlewareError::StreamsNotSupported),
+            #[cfg(all(not(target_arch = "wasm32"), feature = "threaded"))]
+            Body::Stream { stream, .. } => Ok(reqwest::Body::wrap_stream(stream)),
+        }
+    }
+}
+
+fn to_reqwest(request: http::Request<Body>) -> Result<reqwest::Request, MiddlewareError> {
+    let (parts, body) = request.into_parts();
+    let new_request = http::Request::from_parts(parts, reqwest::Body::from(Bytes::new()));
+    let mut request = reqwest::Request::try_from(new_request).map_err(MiddlewareError::Request)?;
+    request.body_mut().replace(body.try_into()?);
+    Ok(request)
+}
+
+fn from_reqwest(response: reqwest::Response) -> Result<http::Response<Body>, MiddlewareError> {
+    let mut builder = http::Response::builder()
+        .status(response.status())
+        .extension(response.url().clone());
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        builder = builder.version(response.version());
+    }
+    if let Some(headers) = builder.headers_mut() {
+        *headers = response.headers().clone()
+    }
+    let size_hint = response
+        .headers()
+        .get(reqwest::header::CONTENT_LENGTH)
+        .and_then(|value| value.to_str().ok()?.parse::<u64>().ok())
+        .map(http_body::SizeHint::with_exact)
+        .unwrap_or_default();
+    builder
+        .body(Body::Stream {
+            size_hint,
+            stream: response
+                .bytes_stream()
+                .map_err(|err| err.into())
+                .boxed_maybe_local(),
+        })
+        .map_err(|err| MiddlewareError::Middleware(err.into()))
+}
+
+pub type Request = http::Request<Body>;
+pub type Response = http::Response<Body>;
+
+pub fn check_status(status: &http::StatusCode) -> Result<(), crate::error::Error> {
+    if status.is_client_error() || status.is_server_error() {
+        Err(crate::error::Error::BadStatus(*status))
+    } else {
+        Ok(())
+    }
+}
 
 #[derive(Clone)]
 pub(crate) struct HttpClient {
@@ -19,21 +242,24 @@ impl HttpClient {
     }
 }
 
-pub type Request = http::Request<reqwest::Body>;
-pub type Response = http::Response<reqwest::Body>;
-
 impl Service<Request> for HttpClient {
     type Response = Response;
     type Error = MiddlewareError;
     type Future = MaybeLocalBoxFuture<'static, Result<Response, MiddlewareError>>;
-    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), MiddlewareError>> {
-        self.client.poll_ready(cx).map_err(MiddlewareError::Request)
+    fn poll_ready(&mut self, _: &mut Context<'_>) -> Poll<Result<(), MiddlewareError>> {
+        Poll::Ready(Ok(()))
     }
     fn call(&mut self, req: Request) -> Self::Future {
         let client = self.client.clone();
-        async move { Ok(client.execute(req.try_into()?).await?.into()) }
-            .map_err(MiddlewareError::Request)
-            .boxed_maybe_local()
+        async move {
+            from_reqwest(
+                client
+                    .execute(to_reqwest(req)?)
+                    .await
+                    .map_err(MiddlewareError::Request)?,
+            )
+        }
+        .boxed_maybe_local()
     }
 }
 
@@ -54,9 +280,9 @@ impl<S> NormalizeHttpService<S> {
 impl<S, ResBody> Service<Request> for NormalizeHttpService<S>
 where
     S: Service<Request, Response = http::Response<ResBody>>,
-    ResBody: http_body::Body + Send + Sync + 'static,
+    ResBody: HttpBody + MaybeSend + 'static,
     ResBody::Data: Into<bytes::Bytes>,
-    ResBody::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
+    ResBody::Error: Into<BoxError>,
 {
     type Response = Response;
     type Error = S::Error;
@@ -67,7 +293,7 @@ where
     fn call(&mut self, req: Request) -> Self::Future {
         self.inner.call(req).map_ok(|res| {
             let (parts, body) = res.into_parts();
-            http::Response::from_parts(parts, reqwest::Body::wrap(body))
+            http::Response::from_parts(parts, Body::wrap(body))
         })
     }
 }

--- a/client/src/multipart.rs
+++ b/client/src/multipart.rs
@@ -715,9 +715,9 @@ mod test {
     #[cfg(feature = "crc32fast")]
     #[tokio::test]
     async fn test_s3_checksum() {
-        use crate::checksum::{crc32fast::Crc32, S3ChecksumMiddleware};
+        use crate::checksum::{crc32fast::Crc32, S3ChecksumLayer};
         let mut client = Client::new("http://localhost:9090".parse().unwrap());
-        client.s3_with(S3ChecksumMiddleware::new(Crc32::new()));
+        client.s3_layer(S3ChecksumLayer::new(Crc32::new()));
         let multipart = AwsMultipart::new("test", "multipart-checksum").await;
         let mut multipart_upload = MultipartUpload::new(client, multipart);
         let mut input = random(100 * MB).await;

--- a/client/src/retry.rs
+++ b/client/src/retry.rs
@@ -2,7 +2,6 @@ use std::ops::RangeInclusive;
 use std::sync::Arc;
 use std::time::Duration;
 
-use bytes::Bytes;
 use tower::retry::{Policy, Retry};
 use tower::Layer;
 
@@ -156,14 +155,14 @@ where
         }
     }
     fn clone_request(&mut self, req: &Request) -> Option<Request> {
-        if let Some(bytes) = req.body().as_bytes() {
+        if let Some(body) = req.body().try_clone() {
             let mut builder = http::request::Builder::new()
                 .method(req.method().clone())
                 .uri(req.uri().clone())
                 .version(req.version());
             *builder.headers_mut()? = req.headers().clone();
             *builder.extensions_mut()? = req.extensions().clone();
-            builder.body(Bytes::copy_from_slice(bytes).into()).ok()
+            builder.body(body).ok()
         } else {
             None
         }

--- a/client/src/ws/mod.rs
+++ b/client/src/ws/mod.rs
@@ -8,7 +8,7 @@ use tower::{Layer, Service, ServiceExt};
 use crate::async_util::{MaybeSend, MaybeSync};
 use crate::client::{get_data, Client};
 use crate::error::{Error, MiddlewareError, Result};
-use crate::http::{HttpBoxService, Request, Response};
+use crate::http::{Body, HttpBoxService, Request, Response};
 
 pub(crate) use tokio_impl::{Websocket, WsClient};
 
@@ -51,7 +51,7 @@ impl Client {
         .with_sub_protocol("graphql-transport-ws")
         .into_client_request()?
         .into_parts();
-        let request = http::Request::from_parts(parts, reqwest::Body::default());
+        let request = http::Request::from_parts(parts, Body::default());
         let (service, mut receiver) = self.ws_service();
         let _ = service.oneshot(request).await?;
         let websocket = receiver.next().await.ok_or_else(|| Error::WsClosed)?;

--- a/client/src/ws/tokio_impl.rs
+++ b/client/src/ws/tokio_impl.rs
@@ -3,7 +3,7 @@ use std::task::{Context, Poll};
 use futures::{channel::mpsc, future::BoxFuture, FutureExt, SinkExt};
 use tower::Service;
 
-use crate::http::{Request, Response};
+use crate::http::{Body, Request, Response};
 
 use crate::error::MiddlewareError;
 
@@ -48,7 +48,7 @@ impl Service<Request> for WsClient {
             let (parts, body) = res.into_parts();
             Ok(http::Response::from_parts(
                 parts,
-                body.map(reqwest::Body::from).unwrap_or_default(),
+                body.map(Body::from).unwrap_or_default(),
             ))
         }
         .boxed()

--- a/src/download.rs
+++ b/src/download.rs
@@ -82,7 +82,7 @@ pub async fn download_archive(
             inspector.inspect(bytes);
         },
     ));
-    tokio::io::copy_buf(&mut response.into_async_read(), &mut tar_file).await?;
+    tokio::io::copy_buf(&mut response.body.into_async_read(), &mut tar_file).await?;
     tar_file.flush().await?;
     drop(tar_file);
 

--- a/src/graphql_client.rs
+++ b/src/graphql_client.rs
@@ -24,6 +24,16 @@ impl From<GraphQLError> for Error {
             GraphQLError::Request(error) => {
                 error::system(&format!("Request failed: {error:?}"), "")
             }
+            GraphQLError::RequestBuilder(error) => {
+                error::system(&format!("Couldn't build request: {error:?}"), "")
+            }
+            GraphQLError::BadStatus(status) => error::system(
+                &format!("Received an invalid response code from server: {status}"),
+                "",
+            ),
+            GraphQLError::StreamNotSupported => {
+                error::system("Streaming is not supported by this client", "")
+            }
             GraphQLError::Json(error) => {
                 error::system(&format!("Failed to parse JSON: {error:?}"), "")
             }
@@ -45,11 +55,11 @@ impl From<GraphQLError> for Error {
             }
             GraphQLError::WsClosed => error::system("Websocket closed early", ""),
             GraphQLError::NoData => error::system("Invalid response received from server", ""),
-            GraphQLError::Middleware(error) => {
-                error::system(&format!("Middleware error: {error:?}"), "")
-            }
             GraphQLError::InvalidHeaderValue(_) => {
                 error::system("Invalid header value from client", "")
+            }
+            GraphQLError::Middleware(error) => {
+                error::system(&format!("Request error: {error:?}"), "")
             }
         }
     }


### PR DESCRIPTION
Ironically this has a lot to do with converting to and from http::Response and reqwest::Response. Because of the way that reqwest has implemented its Response for WASM targets, its not able to directly convert reqwest::Response to http::Response<reqwest::Body> like we do for non-WASM targets. So we've implemented a custom body to handle the conversion as well as some convenience functions.
