### PR TITLE
feat: optional credentials for AQORA_URL

### DIFF
--- a/src/commands/info.rs
+++ b/src/commands/info.rs
@@ -87,7 +87,15 @@ pub async fn info(_: Info, global: GlobalArgs) -> Result<()> {
             .map(|p| p.display().to_string())
             .unwrap_or_else(|err| format!("[error: {err}]"))
     );
-    tracing::info!("URL {}", global.url);
+    tracing::info!(
+        "URL {}",
+        global
+            .aqora_url()
+            .map(|s| s.to_string())
+            .unwrap_or_else(|err| {
+                format!("[error: failed to parse {url}: {err}", url = global.url)
+            })
+    );
     tracing::info!(
         "Viewer {}",
         viewer

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -1,6 +1,6 @@
 use crate::{
     commands::GlobalArgs,
-    credentials::{get_credentials, with_locked_credentials, Credentials},
+    credentials::{with_locked_credentials, Credentials},
     error::{self, Result},
     graphql_client::unauthenticated_client,
 };
@@ -330,10 +330,7 @@ pub async fn login(args: Login, global: GlobalArgs) -> Result<()> {
 }
 
 pub async fn check_login(global: GlobalArgs, multi_progress: &MultiProgress) -> Result<bool> {
-    if get_credentials(global.config_home().await?, global.aqora_url()?)
-        .await?
-        .is_some()
-    {
+    if global.credentials().await?.is_some() {
         return Ok(true);
     }
     let confirmation = multi_progress.suspend(|| {


### PR DESCRIPTION
Allows you to add credentials via the `AQORA_URL` environment variable via

```bash
export AQORA_URL="http(s)://<client_id>:<client_secret>@<host>:<port>?access_token=<access_token>&refresh_token=<refresh_token>&expires_at=<expires_at>
```