### PR TITLE
fix: allow notebook to be configurable

### DIFF
--- a/python/aqora_cli/_aqora_cli.pyi
+++ b/python/aqora_cli/_aqora_cli.pyi
@@ -25,5 +25,10 @@ class Client:
         self, url: str, *, range: tuple[int | None, int | None] | None = None
     ) -> bytes: ...
     async def _download_workspace_notebook(
-        self, owner: str, slug: str, dest: str | Path
-    ) -> None: ...
+        self,
+        owner: str,
+        slug: str,
+        dest_dir: str | Path,
+        notebook: str | None = None,
+        force: bool = False,
+    ) -> str: ...

--- a/python/aqora_cli/notebook.py
+++ b/python/aqora_cli/notebook.py
@@ -47,10 +47,11 @@ def _notebook_cache_dir() -> Path:
     raise PermissionError("Could not find a writable site-packages cache directory")
 
 
-def _module_name(owner: str, slug: str) -> str:
+def _module_name(owner: str, slug: str, filename: str) -> str:
     safe_owner = "".join(c if c.isalnum() or c == "_" else "_" for c in owner)
     safe_slug = "".join(c if c.isalnum() or c == "_" else "_" for c in slug)
-    return f"aqora_cli_workspace_{safe_owner}_{safe_slug}"
+    safe_file = "".join(c if c.isalnum() or c == "_" else "_" for c in Path(filename).stem)
+    return f"aqora_cli_workspace_{safe_owner}_{safe_slug}_{safe_file}"
 
 
 def _path_part(value: str) -> str:
@@ -61,22 +62,34 @@ def _path_part(value: str) -> str:
 async def _notebook_async(
     workspace: str,
     *,
+    filename: str | None = None,
     aqora_url: str | None = None,
     aqora_auth: bool = True,
     force_download: bool = False,
 ) -> ModuleType:
     owner, slug = _parse_workspace_slug(workspace)
-    notebook_path = _notebook_cache_dir() / _path_part(owner) / _path_part(slug) / "readme.py"
-    if force_download or not notebook_path.exists():
-        client = Client(aqora_url)
-        if aqora_auth and not client.authenticated:
-            await client.authenticate()
-        await client._download_workspace_notebook(owner, slug, str(notebook_path))
+    dest_dir = _notebook_cache_dir() / _path_part(owner) / _path_part(slug)
 
-    module_name = _module_name(owner, slug)
-    spec = importlib.util.spec_from_file_location(module_name, notebook_path)
+    if filename and not force_download:
+        notebook_path = dest_dir / filename
+        if notebook_path.exists():
+            return _load_module(owner, slug, filename, notebook_path)
+
+    client = Client(aqora_url)
+    if aqora_auth and not client.authenticated:
+        await client.authenticate()
+    actual_filename = await client._download_workspace_notebook(
+        owner, slug, str(dest_dir), filename, force_download
+    )
+    notebook_path = dest_dir / actual_filename
+    return _load_module(owner, slug, actual_filename, notebook_path)
+
+
+def _load_module(owner: str, slug: str, filename: str, path: Path) -> ModuleType:
+    module_name = _module_name(owner, slug, filename)
+    spec = importlib.util.spec_from_file_location(module_name, path)
     if spec is None or spec.loader is None:
-        raise ImportError(f"Could not create module spec for '{notebook_path}'")
+        raise ImportError(f"Could not create module spec for '{path}'")
     module = importlib.util.module_from_spec(spec)
     sys.modules[module_name] = module
     spec.loader.exec_module(module)
@@ -86,12 +99,14 @@ async def _notebook_async(
 def notebook(
     workspace: str,
     *,
+    filename: str | None = None,
     aqora_url: str | None = None,
     aqora_auth: bool = True,
     force_download: bool = False,
 ) -> ModuleType | Coroutine[Any, Any, ModuleType]:
     coro = _notebook_async(
         workspace,
+        filename=filename,
         aqora_url=aqora_url,
         aqora_auth=aqora_auth,
         force_download=force_download,

--- a/schema.graphql
+++ b/schema.graphql
@@ -3461,6 +3461,7 @@ type Workspace implements Votable & ForumOwner & Node & Taggable {
 	voters(after: String, before: String, first: Int, last: Int): VotersConnection!
 	tags(after: String, before: String, first: Int, last: Int): TaggableConnection!
 	entries: [WorkspaceEntry!]
+	defaultNotebook: String
 	versions(after: String, before: String, first: Int, last: Int): WorkspaceVersionConnection!
 	version(version: Semver!): WorkspaceVersion
 	latestVersion: WorkspaceVersion

--- a/src/graphql/get_workspace_notebook_download_url.graphql
+++ b/src/graphql/get_workspace_notebook_download_url.graphql
@@ -1,5 +1,6 @@
 query GetWorkspaceNotebookDownloadUrl($owner: String!, $slug: String!) {
   workspaceBySlug(owner: $owner, slug: $slug) {
+    defaultNotebook
     entries {
       __typename
       ... on WorkspaceFile {

--- a/src/python_module.rs
+++ b/src/python_module.rs
@@ -202,22 +202,26 @@ impl PyClient {
         })
     }
 
+    #[pyo3(signature = (owner, slug, dest_dir, notebook=None, force=false))]
     fn _download_workspace_notebook<'py>(
         &self,
         py: Python<'py>,
         owner: &str,
         slug: &str,
-        dest: std::path::PathBuf,
+        dest_dir: std::path::PathBuf,
+        notebook: Option<String>,
+        force: bool,
     ) -> PyResult<Bound<'py, PyAny>> {
         let inner = Arc::clone(&self.inner);
         let owner = owner.to_owned();
         let slug = slug.to_owned();
         future_into_py(py, async move {
             let client = inner.read().await.client.clone();
-            download_workspace_notebook(client, owner, slug, dest)
-                .await
-                .map_err(|error| ClientError::new_err((error.message(),)))?;
-            Ok(())
+            let filename =
+                download_workspace_notebook(client, owner, slug, dest_dir, notebook, force)
+                    .await
+                    .map_err(|error| ClientError::new_err((error.message(),)))?;
+            Ok(filename)
         })
     }
 

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -16,8 +16,10 @@ pub async fn download_workspace_notebook(
     client: aqora_client::Client,
     owner: String,
     slug: String,
-    dest: impl AsRef<Path>,
-) -> Result<()> {
+    dest_dir: impl AsRef<Path>,
+    notebook: Option<String>,
+    force: bool,
+) -> Result<String> {
     let workspace = client
         .send::<GetWorkspaceNotebookDownloadUrl>(get_workspace_notebook_download_url::Variables {
             owner: owner.clone(),
@@ -32,6 +34,21 @@ pub async fn download_workspace_notebook(
             )
         })?;
 
+    let notebook_name = notebook.or(workspace.default_notebook).ok_or_else(|| {
+        error::user(
+            &format!(
+                "No notebook specified and workspace '{owner}/{slug}' has no default notebook"
+            ),
+            "Please provide a filename or set a default notebook on the workspace",
+        )
+    })?;
+
+    let dest = dest_dir.as_ref().join(&notebook_name);
+
+    if !force && dest.exists() {
+        return Ok(notebook_name);
+    }
+
     let download_url = workspace
         .entries
         .unwrap_or_default()
@@ -39,44 +56,56 @@ pub async fn download_workspace_notebook(
         .find_map(|entry| match entry {
             get_workspace_notebook_download_url::GetWorkspaceNotebookDownloadUrlWorkspaceBySlugEntries::WorkspaceFile(
                 file,
-            ) if file.name == "readme.py" => file.download_url,
+            ) if file.name == notebook_name => file.download_url,
             _ => None,
         })
         .ok_or_else(|| {
             error::user(
-                &format!("File 'readme.py' not found in workspace '{owner}/{slug}'"),
-                "Please make sure the workspace contains a readme.py entry",
+                &format!("File '{notebook_name}' not found in workspace '{owner}/{slug}'"),
+                "Please make sure the workspace contains this file",
             )
         })?;
 
-    let dest = dest.as_ref();
-    if let Some(parent) = dest.parent().filter(|p| !p.as_os_str().is_empty()) {
-        tokio::fs::create_dir_all(parent).await.map_err(|e| {
-            error::user(
-                &format!(
-                    "Failed to create destination directory '{}': {e}",
-                    parent.display()
-                ),
-                "Please check your write permissions for the destination path",
-            )
-        })?;
-    }
-
-    let response = client.s3_get(download_url).await?;
-    let file = tokio::fs::File::create(dest).await.map_err(|e| {
+    let dest_dir = dest_dir.as_ref();
+    tokio::fs::create_dir_all(dest_dir).await.map_err(|e| {
         error::user(
             &format!(
-                "Failed to create destination file '{}': {e}",
-                dest.display()
+                "Failed to create destination directory '{}': {e}",
+                dest_dir.display()
             ),
             "Please check your write permissions for the destination path",
         )
     })?;
 
+    let temp = tempfile::NamedTempFile::new_in(dest_dir).map_err(|e| {
+        error::user(
+            &format!(
+                "Failed to create temporary file in '{}': {e}",
+                dest_dir.display()
+            ),
+            "Please check your write permissions for the destination path",
+        )
+    })?;
+    let temp_path = temp.path().to_owned();
+
+    let response = client.s3_get(download_url).await?;
+    let file = tokio::fs::File::from_std(temp.into_file());
+
     let mut reader = response.body.into_async_read();
     let mut writer = tokio::io::BufWriter::new(file);
-    tokio::io::copy_buf(&mut reader, &mut writer).await?;
-    writer.flush().await?;
-
-    Ok(())
+    match async {
+        tokio::io::copy_buf(&mut reader, &mut writer).await?;
+        writer.flush().await
+    }
+    .await
+    {
+        Ok(()) => {
+            tokio::fs::rename(&temp_path, &dest).await?;
+            Ok(notebook_name)
+        }
+        Err(e) => {
+            let _ = tokio::fs::remove_file(&temp_path).await;
+            Err(e.into())
+        }
+    }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Specify which notebook to download from a workspace (filename parameter).
  * Workspaces can expose a default notebook (new GraphQL field).

* **Improvements**
  * Per-workspace destination directory caching and reuse; deterministic module naming to avoid collisions.
  * Optional "force" flag to re-download a notebook.
  * Safer download (temp file + atomic rename) and clearer import error messages.

* **Bug Fixes**
  * Skip downloads when target notebook file already exists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->