### PR TITLE
feat(auth): add 'aqora auth token' for external consumers

### DIFF
--- a/src/commands/auth/mod.rs
+++ b/src/commands/auth/mod.rs
@@ -1,0 +1,20 @@
+mod token;
+
+use clap::Subcommand;
+use serde::Serialize;
+
+use crate::commands::GlobalArgs;
+use crate::error::Result;
+
+use token::{token, Token};
+
+#[derive(Subcommand, Debug, Serialize)]
+pub enum Auth {
+    Token(Token),
+}
+
+pub async fn auth(args: Auth, global: GlobalArgs) -> Result<()> {
+    match args {
+        Auth::Token(args) => token(args, global).await,
+    }
+}

--- a/src/commands/auth/token.rs
+++ b/src/commands/auth/token.rs
@@ -1,0 +1,50 @@
+use crate::{
+    commands::GlobalArgs,
+    credentials::load_refreshed_credentials,
+    dirs::credentials_path,
+    error::{self, Result},
+    graphql_client::unauthenticated_client,
+};
+use aqora_client::ClientOptions;
+use clap::Args;
+use serde::Serialize;
+use url::Url;
+
+#[derive(Args, Debug, Serialize)]
+#[command(
+    author,
+    version,
+    about = "Print a valid aqora access token on stdout, refreshing if needed"
+)]
+pub struct Token {
+    #[arg(
+        long,
+        help = "Target a specific aqora API URL instead of the default. Useful when logged into multiple environments."
+    )]
+    url: Option<String>,
+}
+
+pub async fn token(args: Token, global: GlobalArgs) -> Result<()> {
+    let url = match args.url.as_deref() {
+        Some(url) => Url::parse(url)?,
+        None => global.aqora_url()?,
+    };
+    let path = credentials_path(global.config_home().await?);
+    let client = unauthenticated_client(url.clone(), ClientOptions::default())?;
+    let loaded = load_refreshed_credentials(&path, &url, &client)
+        .await
+        .map_err(|e| {
+            error::system(
+                &format!("Failed to load credentials for {url}: {e}"),
+                "Check your configuration and try again.",
+            )
+        })?;
+    let Some((_guard, credentials)) = loaded else {
+        return Err(error::user(
+            &format!("Not logged in to {url}"),
+            "Run 'aqora login' to authenticate.",
+        ));
+    };
+    println!("{}", credentials.access_token);
+    Ok(())
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,4 +1,5 @@
 mod add;
+mod auth;
 mod clean;
 mod dataset;
 mod global_args;
@@ -20,6 +21,7 @@ use serde::Serialize;
 pub use global_args::GlobalArgs;
 
 use add::{add, Add};
+use auth::{auth, Auth};
 use clean::{clean, Clean};
 use dataset::{dataset, Dataset};
 use info::{info, Info};
@@ -62,6 +64,10 @@ pub enum Commands {
         args: Dataset,
     },
     Login(Login),
+    Auth {
+        #[command(subcommand)]
+        args: Auth,
+    },
     Python(Python),
     Shell(Shell),
     Test(Test),
@@ -89,6 +95,7 @@ impl Cli {
                 Commands::New { args } => new(args, global).await,
                 Commands::Dataset { args } => dataset(args, global).await,
                 Commands::Login(args) => login(args, global).await,
+                Commands::Auth { args } => auth(args, global).await,
                 Commands::Python(args) => python(args, global).await,
                 Commands::Shell(args) => shell(args, global).await,
                 Commands::Test(args) => test(args, global).await,

--- a/src/credentials.rs
+++ b/src/credentials.rs
@@ -146,7 +146,7 @@ async fn refresh_credentials(
     Ok(())
 }
 
-async fn load_refreshed_credentials(
+pub async fn load_refreshed_credentials(
     path: &Path,
     url: &Url,
     unauthenticated_client: &aqora_client::Client,


### PR DESCRIPTION
**This pull request was authored by a coding agent on behalf of @stubbi (jannes@aqora.io).**

## Motivation

External consumers (aqora-io/skills, CI jobs, other agents, third-party tools) need a stable contract to get a valid aqora access token. Today they have to read `credentials.json` directly, which does not trigger the CLI's existing refresh logic, so tokens silently go stale after their short lifetime.

This adds `aqora auth token`, matching the well-established pattern from `gh auth token`, `gcloud auth print-access-token`, and `aws configure export-credentials`. One clean contract: print a fresh access token on stdout, refreshing as needed.

Context: https://github.com/aqora-io/skills/issues/1 (separate issue, but the skills repo was where this need surfaced).

## What this PR does

- Adds an `auth` command group and a `token` subcommand under it.
- `aqora auth token` prints a valid access token on stdout for the current API URL.
- Reuses `credentials::load_refreshed_credentials` so refresh is transparent; no new auth code.
- Optional `--url URL` flag to target a specific API URL when logged into multiple environments.
- Exits 1 with a clear stderr message when not logged in.
- No change to existing `aqora login` behavior.

## What this PR explicitly does not do

- No `aqora auth login`, `logout`, or `status` subcommands. Those are obvious follow-ups but scope creep here.
- No change to credential storage format.
- No change to `login`, `shell`, `lab`, or any other existing command.

## Testing

1. Build: `cargo build --release` clean, no new warnings.
2. Clippy: `cargo clippy --all-targets` no new warnings.
3. Live token test against the production API:

   ```
   $ tok=$(cargo run --release --quiet -- auth token)
   $ echo "Token length: ${#tok}"
   Token length: 50
   $ curl -fsS -X POST -H "Authorization: Bearer $tok" -H "Content-Type: application/json" \
       --data '{"query":"{ viewer { id } }"}' https://aqora.io/graphql
   {"data":{"viewer":{"id":"AFVzZXIBjTXKssp7bIhK6mkQ35U9"}}}
   ```

4. Error path: used `--url https://bogus.example` and confirmed the expected stderr message and exit 1:

   ```
   $ cargo run --release --quiet -- auth token --url https://bogus.example
   ERROR Oh no! Not logged in to https://bogus.example/

   To try and fix this, you can:
    - Run 'aqora login' to authenticate.
   $ echo $?
   1
   ```

## Reviewer notes

Small surface area. The entire change is wiring plus a call into `credentials::load_refreshed_credentials` (previously a private helper, now exported). Suggested follow-ups for a future PR: `aqora auth login` as alias, `aqora auth logout`, `aqora auth status`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `auth` command with `token` subcommand to retrieve and display access tokens
  * Support for optional `--url` parameter to specify a custom API endpoint
  * Clear error messages guide users to authenticate when credentials are unavailable

<!-- end of auto-generated comment: release notes by coderabbit.ai -->