### PR TITLE
chore: update to arrow-58

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -365,8 +365,8 @@ dependencies = [
 
 [[package]]
 name = "arrow"
-version = "56.1.0"
-source = "git+https://github.com/aqora-io/arrow-rs?branch=dataset#b989c1333bca9f53fc9717824ab1ef8250909c52"
+version = "58.1.0"
+source = "git+https://github.com/aqora-io/arrow-rs?branch=dataset#0805fa524c60e848b3ad2cd9364c1b834ab622ee"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -383,21 +383,21 @@ dependencies = [
 
 [[package]]
 name = "arrow-arith"
-version = "56.1.0"
-source = "git+https://github.com/aqora-io/arrow-rs?branch=dataset#b989c1333bca9f53fc9717824ab1ef8250909c52"
+version = "58.1.0"
+source = "git+https://github.com/aqora-io/arrow-rs?branch=dataset#0805fa524c60e848b3ad2cd9364c1b834ab622ee"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
  "arrow-data",
  "arrow-schema",
  "chrono",
- "num",
+ "num-traits",
 ]
 
 [[package]]
 name = "arrow-array"
-version = "56.1.0"
-source = "git+https://github.com/aqora-io/arrow-rs?branch=dataset#b989c1333bca9f53fc9717824ab1ef8250909c52"
+version = "58.1.0"
+source = "git+https://github.com/aqora-io/arrow-rs?branch=dataset#0805fa524c60e848b3ad2cd9364c1b834ab622ee"
 dependencies = [
  "ahash",
  "arrow-buffer",
@@ -406,27 +406,31 @@ dependencies = [
  "chrono",
  "half",
  "hashbrown 0.16.0",
- "num",
+ "num-complex",
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
 name = "arrow-buffer"
-version = "56.1.0"
-source = "git+https://github.com/aqora-io/arrow-rs?branch=dataset#b989c1333bca9f53fc9717824ab1ef8250909c52"
+version = "58.1.0"
+source = "git+https://github.com/aqora-io/arrow-rs?branch=dataset#0805fa524c60e848b3ad2cd9364c1b834ab622ee"
 dependencies = [
  "bytes",
  "half",
- "num",
+ "num-bigint",
+ "num-traits",
 ]
 
 [[package]]
 name = "arrow-cast"
-version = "56.1.0"
-source = "git+https://github.com/aqora-io/arrow-rs?branch=dataset#b989c1333bca9f53fc9717824ab1ef8250909c52"
+version = "58.1.0"
+source = "git+https://github.com/aqora-io/arrow-rs?branch=dataset#0805fa524c60e848b3ad2cd9364c1b834ab622ee"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
  "arrow-data",
+ "arrow-ord",
  "arrow-schema",
  "arrow-select",
  "atoi",
@@ -434,25 +438,26 @@ dependencies = [
  "chrono",
  "half",
  "lexical-core",
- "num",
+ "num-traits",
  "ryu",
 ]
 
 [[package]]
 name = "arrow-data"
-version = "56.1.0"
-source = "git+https://github.com/aqora-io/arrow-rs?branch=dataset#b989c1333bca9f53fc9717824ab1ef8250909c52"
+version = "58.1.0"
+source = "git+https://github.com/aqora-io/arrow-rs?branch=dataset#0805fa524c60e848b3ad2cd9364c1b834ab622ee"
 dependencies = [
  "arrow-buffer",
  "arrow-schema",
  "half",
- "num",
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
 name = "arrow-ipc"
-version = "56.1.0"
-source = "git+https://github.com/aqora-io/arrow-rs?branch=dataset#b989c1333bca9f53fc9717824ab1ef8250909c52"
+version = "58.1.0"
+source = "git+https://github.com/aqora-io/arrow-rs?branch=dataset#0805fa524c60e848b3ad2cd9364c1b834ab622ee"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -466,8 +471,8 @@ dependencies = [
 
 [[package]]
 name = "arrow-ord"
-version = "56.1.0"
-source = "git+https://github.com/aqora-io/arrow-rs?branch=dataset#b989c1333bca9f53fc9717824ab1ef8250909c52"
+version = "58.1.0"
+source = "git+https://github.com/aqora-io/arrow-rs?branch=dataset#0805fa524c60e848b3ad2cd9364c1b834ab622ee"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -478,8 +483,8 @@ dependencies = [
 
 [[package]]
 name = "arrow-row"
-version = "56.1.0"
-source = "git+https://github.com/aqora-io/arrow-rs?branch=dataset#b989c1333bca9f53fc9717824ab1ef8250909c52"
+version = "58.1.0"
+source = "git+https://github.com/aqora-io/arrow-rs?branch=dataset#0805fa524c60e848b3ad2cd9364c1b834ab622ee"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -490,26 +495,26 @@ dependencies = [
 
 [[package]]
 name = "arrow-schema"
-version = "56.1.0"
-source = "git+https://github.com/aqora-io/arrow-rs?branch=dataset#b989c1333bca9f53fc9717824ab1ef8250909c52"
+version = "58.1.0"
+source = "git+https://github.com/aqora-io/arrow-rs?branch=dataset#0805fa524c60e848b3ad2cd9364c1b834ab622ee"
 
 [[package]]
 name = "arrow-select"
-version = "56.1.0"
-source = "git+https://github.com/aqora-io/arrow-rs?branch=dataset#b989c1333bca9f53fc9717824ab1ef8250909c52"
+version = "58.1.0"
+source = "git+https://github.com/aqora-io/arrow-rs?branch=dataset#0805fa524c60e848b3ad2cd9364c1b834ab622ee"
 dependencies = [
  "ahash",
  "arrow-array",
  "arrow-buffer",
  "arrow-data",
  "arrow-schema",
- "num",
+ "num-traits",
 ]
 
 [[package]]
 name = "arrow-string"
-version = "56.1.0"
-source = "git+https://github.com/aqora-io/arrow-rs?branch=dataset#b989c1333bca9f53fc9717824ab1ef8250909c52"
+version = "58.1.0"
+source = "git+https://github.com/aqora-io/arrow-rs?branch=dataset#0805fa524c60e848b3ad2cd9364c1b834ab622ee"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -517,7 +522,7 @@ dependencies = [
  "arrow-schema",
  "arrow-select",
  "memchr",
- "num",
+ "num-traits",
  "regex",
  "regex-syntax 0.8.5",
 ]
@@ -3244,11 +3249,11 @@ dependencies = [
 
 [[package]]
 name = "lz4_flex"
-version = "0.11.3"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75761162ae2b0e580d7e7c390558127e5f01b4194debd6221fd8c207fc80e3f5"
+checksum = "db9a0d582c2874f68138a16ce1867e0ffde6c0bb0a0df85e1f36d04146db488a"
 dependencies = [
- "twox-hash 1.6.3",
+ "twox-hash",
 ]
 
 [[package]]
@@ -3274,9 +3279,9 @@ dependencies = [
 
 [[package]]
 name = "marrow"
-version = "0.2.4"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64369333feea08a4c974cc5d7bad82197999624d0c9508bec4b97ea9fc0e3f63"
+checksum = "f5240d6977234968ff9ad254bfa73aa397fb51e41dcb22b1eb85835e9295485b"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -3407,20 +3412,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
-dependencies = [
- "num-bigint",
- "num-complex",
- "num-integer",
- "num-iter",
- "num-rational",
- "num-traits",
-]
-
-[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3455,17 +3446,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-iter"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
 name = "num-modular"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3478,17 +3458,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "537b596b97c40fcf8056d153049eb22f481c17ebce72a513ec9286e4986d1bb6"
 dependencies = [
  "num-modular",
-]
-
-[[package]]
-name = "num-rational"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
-dependencies = [
- "num-bigint",
- "num-integer",
- "num-traits",
 ]
 
 [[package]]
@@ -3667,13 +3636,12 @@ dependencies = [
 
 [[package]]
 name = "parquet"
-version = "56.1.0"
-source = "git+https://github.com/aqora-io/arrow-rs?branch=dataset#b989c1333bca9f53fc9717824ab1ef8250909c52"
+version = "58.1.0"
+source = "git+https://github.com/aqora-io/arrow-rs?branch=dataset#0805fa524c60e848b3ad2cd9364c1b834ab622ee"
 dependencies = [
  "ahash",
  "arrow-array",
  "arrow-buffer",
- "arrow-cast",
  "arrow-data",
  "arrow-ipc",
  "arrow-schema",
@@ -3687,15 +3655,16 @@ dependencies = [
  "half",
  "hashbrown 0.16.0",
  "lz4_flex",
- "num",
  "num-bigint",
+ "num-integer",
+ "num-traits",
  "paste",
  "seq-macro",
  "simdutf8",
  "snap",
  "thrift",
  "tokio",
- "twox-hash 2.1.0",
+ "twox-hash",
  "zstd",
 ]
 
@@ -4813,9 +4782,9 @@ dependencies = [
 
 [[package]]
 name = "serde_arrow"
-version = "0.13.6"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "197c925e607eaed897d7912f53895097c6994fdc04fe5f7a2e61eb3898de1d26"
+checksum = "2784e59a0315568e850cb01ddadf458f8c09e28d8cfc4880c2cc08f5dc3444e0"
 dependencies = [
  "arrow-array",
  "arrow-schema",
@@ -5597,16 +5566,6 @@ dependencies = [
  "sha1",
  "thiserror 1.0.69",
  "utf-8",
-]
-
-[[package]]
-name = "twox-hash"
-version = "1.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
-dependencies = [
- "cfg-if",
- "static_assertions",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,7 +110,7 @@ qrcode = { version = "0.14.1", default-features = false }
 regex = "1.11.1"
 comfy-table = "7.1.4"
 ron = { version = "0.10", features = ["indexmap"] }
-parquet = { version = "56" }
+parquet = { version = "58" }
 async-trait = "0.1"
 bytes = "1.10"
 content_disposition = "0.4.0"

--- a/data-utils/Cargo.toml
+++ b/data-utils/Cargo.toml
@@ -110,10 +110,10 @@ http = { version = "1.3", optional = true }
 http-body = { version = "1.0", optional = true }
 http-serde = { version = "2.1", optional = true }
 
-arrow = { version = "56", default-features = false }
-arrow-ipc = { version = "56", default-features = false, optional = true }
-serde_arrow = { version = "0.13.5", features = ["arrow-56"] }
-parquet = { version = "56", default-features = false, features = [
+arrow = { version = "58", default-features = false }
+arrow-ipc = { version = "58", default-features = false, optional = true }
+serde_arrow = { version = "0.14", features = ["arrow-58"] }
+parquet = { version = "58", default-features = false, features = [
   "async",
   "arrow",
   "simdutf8",

--- a/data-utils/src/infer.rs
+++ b/data-utils/src/infer.rs
@@ -117,8 +117,8 @@ fn field_to_serde_arrow_overwrite(
     field: FieldRef,
 ) -> Result<serde_json::Value, serde_arrow::Error> {
     let schema = serde_arrow::schema::SerdeArrowSchema::try_from([field].as_slice())?;
-    if let serde_json::Value::Object(mut map) =
-        serde_json::to_value(schema).map_err(|err| serde_arrow::Error::custom(err.to_string()))?
+    if let serde_json::Value::Object(mut map) = serde_json::to_value(schema)
+        .map_err(|err| serde_arrow::Error::new(serde_arrow::ErrorKind::Custom, err.to_string()))?
     {
         if let Some(serde_json::Value::Array(mut arr)) = map.remove("fields") {
             if let Some(field) = arr.pop() {
@@ -126,7 +126,8 @@ fn field_to_serde_arrow_overwrite(
             }
         }
     }
-    Err(serde_arrow::Error::custom(
+    Err(serde_arrow::Error::new(
+        serde_arrow::ErrorKind::Custom,
         "Invalid JSON returned for SerdeArrowSchema".into(),
     ))
 }

--- a/data-utils/src/wasm/write.rs
+++ b/data-utils/src/wasm/write.rs
@@ -356,7 +356,7 @@ pub struct JsSortingColumn {
     nulls_first: bool,
 }
 
-impl From<JsSortingColumn> for parquet::format::SortingColumn {
+impl From<JsSortingColumn> for parquet::file::metadata::SortingColumn {
     fn from(value: JsSortingColumn) -> Self {
         Self {
             column_idx: value.column_idx,
@@ -375,7 +375,7 @@ pub struct JsKeyValue {
     value: Option<String>,
 }
 
-impl From<JsKeyValue> for parquet::format::KeyValue {
+impl From<JsKeyValue> for parquet::file::metadata::KeyValue {
     fn from(value: JsKeyValue) -> Self {
         Self {
             key: value.key,
@@ -470,7 +470,7 @@ impl TryFrom<JsWriterProperties> for parquet::file::properties::WriterProperties
             builder = builder.set_write_batch_size(write_batch_size);
         }
         if let Some(max_row_group_size) = value.max_row_group_size {
-            builder = builder.set_max_row_group_size(max_row_group_size);
+            builder = builder.set_max_row_group_row_count(Some(max_row_group_size));
         }
         if let Some(bloom_filter_position) = value.bloom_filter_position {
             builder = builder.set_bloom_filter_position(bloom_filter_position.into());

--- a/data-utils/src/write.rs
+++ b/data-utils/src/write.rs
@@ -12,7 +12,7 @@ use pin_project::pin_project;
 
 pub use parquet::arrow::arrow_writer::ArrowWriterOptions as Options;
 pub use parquet::arrow::async_writer::AsyncFileWriter;
-pub use parquet::format::FileMetaData;
+pub use parquet::file::metadata::ParquetMetaData;
 
 use crate::async_util::parquet_async::*;
 use crate::error::{Error, Result};
@@ -80,7 +80,7 @@ where
 
 async fn close_part<W>(
     mut part_writer: AsyncArrowWriter<W::Writer>,
-) -> Result<(W::Writer, FileMetaData)>
+) -> Result<(W::Writer, ParquetMetaData)>
 where
     W: AsyncPartitionWriter,
 {
@@ -89,7 +89,7 @@ where
     Ok((writer, meta))
 }
 
-type ClosePartFut<'w, Writer> = BoxFuture<'w, Result<(Writer, FileMetaData)>>;
+type ClosePartFut<'w, Writer> = BoxFuture<'w, Result<(Writer, ParquetMetaData)>>;
 
 async fn create_part<W>(
     mut writer: W,
@@ -207,7 +207,7 @@ where
     S: Stream<Item = Result<RecordBatch, Error>> + MaybeSend + Unpin,
     W: AsyncPartitionWriter + MaybeSend,
 {
-    type Item = Result<(W::Writer, FileMetaData), Error>;
+    type Item = Result<(W::Writer, ParquetMetaData), Error>;
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let this = self.project();
         loop {
@@ -407,7 +407,7 @@ mod test {
         while let Some((file, meta)) = parquets.try_next().await.unwrap() {
             file_count += 1;
             assert!(file.metadata().await.unwrap().len() > 0);
-            assert!(meta.num_rows > 0);
+            assert!(meta.file_metadata().num_rows() > 0);
         }
         assert_eq!(file_count, 1);
     }

--- a/src/commands/dataset/convert.rs
+++ b/src/commands/dataset/convert.rs
@@ -97,9 +97,9 @@ pub struct SortingColumn {
     pub nulls_first: bool,
 }
 
-impl From<SortingColumn> for parquet::format::SortingColumn {
+impl From<SortingColumn> for parquet::file::metadata::SortingColumn {
     fn from(value: SortingColumn) -> Self {
-        parquet::format::SortingColumn {
+        parquet::file::metadata::SortingColumn {
             column_idx: value.column_idx,
             descending: value.descending,
             nulls_first: value.nulls_first,
@@ -258,7 +258,7 @@ impl WriteOptions {
             .set_data_page_row_count_limit(self.data_page_row_count)
             .set_dictionary_page_size_limit(self.dictionary_page_size)
             .set_write_batch_size(self.write_batch_size)
-            .set_max_row_group_size(self.max_row_group_size)
+            .set_max_row_group_row_count(Some(self.max_row_group_size))
             .set_bloom_filter_position(self.bloom_filter_position.into())
             .set_offset_index_disabled(self.offset_index_disabled)
             .set_dictionary_enabled(!self.no_dictionary_enabled)
@@ -431,7 +431,10 @@ pub async fn convert(args: Convert, global: GlobalArgs) -> Result<()> {
     pb.set_style(indicatif::ProgressStyle::default_spinner());
     pb.finish_with_message(format!(
         "{} records written",
-        metadata.iter().map(|(_, meta)| meta.num_rows).sum::<i64>(),
+        metadata
+            .iter()
+            .map(|(_, meta)| meta.file_metadata().num_rows())
+            .sum::<i64>(),
     ));
     Ok(())
 }

--- a/src/commands/dataset/upload.rs
+++ b/src/commands/dataset/upload.rs
@@ -268,7 +268,7 @@ pub async fn upload(args: Upload, global: GlobalArgs) -> Result<()> {
     let written_records =
         write::ParquetStream::new(stream, writer, schema, write_options, args.buffer.parse())
             .try_fold(0usize, async |acc, (_part, meta)| {
-                Ok(acc + 0usize.saturating_add_signed(meta.num_rows as _))
+                Ok(acc + 0usize.saturating_add_signed(meta.file_metadata().num_rows() as _))
             })
             .await
             .map_err(|err| {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Dependencies**
  * Upgraded parquet and arrow crate dependencies (parquet and arrow from v56 to v58; serde_arrow from 0.13.5 to 0.14).

* **Refactor**
  * Updated internal code for compatibility with upgraded parquet library versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->