### PR TITLE
chore: bump marimo version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -139,7 +139,7 @@ dependencies = [
 
 [[package]]
 name = "aqora"
-version = "0.24.0"
+version = "0.24.1"
 dependencies = [
  "aqora-archiver",
  "aqora-client",
@@ -210,7 +210,7 @@ dependencies = [
 
 [[package]]
 name = "aqora-archiver"
-version = "0.24.0"
+version = "0.24.1"
 dependencies = [
  "crc32fast",
  "flate2",
@@ -231,7 +231,7 @@ dependencies = [
 
 [[package]]
 name = "aqora-client"
-version = "0.24.0"
+version = "0.24.1"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -263,7 +263,7 @@ dependencies = [
 
 [[package]]
 name = "aqora-config"
-version = "0.24.0"
+version = "0.24.1"
 dependencies = [
  "pep440_rs",
  "pep508_rs",
@@ -275,7 +275,7 @@ dependencies = [
 
 [[package]]
 name = "aqora-data-utils"
-version = "0.24.0"
+version = "0.24.1"
 dependencies = [
  "aqora-client",
  "arrow",
@@ -324,7 +324,7 @@ dependencies = [
 
 [[package]]
 name = "aqora-runner"
-version = "0.24.0"
+version = "0.24.1"
 dependencies = [
  "aqora-config",
  "clap",
@@ -341,7 +341,7 @@ dependencies = [
 
 [[package]]
 name = "aqora-template"
-version = "0.24.0"
+version = "0.24.1"
 dependencies = [
  "derive_builder",
  "handlebars",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["archiver", "config", "runner", "template", "data-utils", "client"]
 
 [workspace.package]
-version = "0.24.0"
+version = "0.24.1"
 license = "MIT"
 
 [package]

--- a/docker/Dockerfile.kubimo
+++ b/docker/Dockerfile.kubimo
@@ -1,4 +1,4 @@
-ARG KUBIMO_MARIMO_IMAGE=ghcr.io/aqora-io/kubimo-marimo:0.1.17
+ARG KUBIMO_MARIMO_IMAGE=ghcr.io/aqora-io/kubimo-marimo:0.1.18
 
 FROM ${KUBIMO_MARIMO_IMAGE} AS build
 

--- a/template/src/dataset_marimo.rs
+++ b/template/src/dataset_marimo.rs
@@ -8,7 +8,7 @@ use crate::registry::REGISTRY;
 use crate::utils::{assert_semver, assert_slug, assert_username, OptionExt};
 
 const DEFAULT_PYTHON_VERSION: &str = "3.10";
-const DEFAULT_MARIMO_VERSION: &str = "0.23.2";
+const DEFAULT_MARIMO_VERSION: &str = "0.23.3";
 const DEFAULT_CLI_VERSION_STR: &str = env!("CARGO_PKG_VERSION");
 
 #[derive(Builder, Serialize, Debug)]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped workspace version from 0.24.0 to 0.24.1
  * Updated Kubimo Marimo Docker image from version 0.1.17 to 0.1.18
  * Updated default Marimo template version from 0.23.2 to 0.23.3

<!-- end of auto-generated comment: release notes by coderabbit.ai -->