### PR TITLE
fix: add default downloads to template

### DIFF
--- a/template/assets/dataset_marimo/readme.py.hbs
+++ b/template/assets/dataset_marimo/readme.py.hbs
@@ -1,7 +1,7 @@
 import marimo
 
 __generated_with = "{{ marimo_version }}"
-app = marimo.App(width="full", auto_download=["html"])
+app = marimo.App(width="full", auto_download=["html", "markdown", "ipynb"])
 
 
 @app.cell(hide_code=True)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Marimo app template now supports exporting notebooks in Markdown and IPython Notebook formats, in addition to HTML downloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->