### PR TITLE
fix: pull latest aqora version based on DOCKER_META_VERSION

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -150,6 +150,10 @@ jobs:
             type=semver,pattern={{major}}
       - name: Build and push
         uses: docker/bake-action@v6
+        env:
+          # Pin aqora to the release version only for tag builds; non-tag
+          # builds (main/PR/merge_group/dispatch) install the latest release.
+          AQORA_VERSION: ${{ startsWith(github.ref, 'refs/tags/') && steps.meta-kubimo.outputs.version || '' }}
         with:
           set: |
             kubimo*.cache-from=type=registry,ref=ghcr.io/aqora-io/cli-kubimo:latest

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -2,10 +2,20 @@ group "default" {
   targets = ["kubimo"]
 }
 
+# Pin for the aqora PyPI package. Empty installs the latest published release;
+# set from the env var of the same name (see the Release workflow, which only
+# populates it for semver tag builds).
+variable "AQORA_VERSION" {
+  default = ""
+}
+
 target "docker-metadata-kubimo" {}
 
 target "kubimo" {
   inherits = ["docker-metadata-kubimo"]
   context = "."
   dockerfile = "docker/Dockerfile.kubimo"
+  args = {
+    AQORA_VERSION = AQORA_VERSION
+  }
 }

--- a/docker/Dockerfile.kubimo
+++ b/docker/Dockerfile.kubimo
@@ -2,11 +2,14 @@ ARG KUBIMO_MARIMO_IMAGE=ghcr.io/aqora-io/kubimo-marimo:0.1.23
 
 FROM ${KUBIMO_MARIMO_IMAGE}
 
-ARG AQORA_VERSION=0.25.0
+# Optional pin for the aqora PyPI package. Empty installs the latest published
+# release (local dev + non-tag CI builds); tagged releases pass the exact
+# version via the AQORA_VERSION bake variable in docker-bake.hcl.
+ARG AQORA_VERSION=
 USER root
 RUN --mount=type=cache,target=/root/.cache/uv,sharing=locked \
     --mount=type=cache,target=/root/.local/share/uv/python,sharing=locked \
-  uv pip install --system "aqora==${AQORA_VERSION}"
+  uv pip install --system "aqora${AQORA_VERSION:+==${AQORA_VERSION}}"
 
 USER me
 WORKDIR /home/me/workspace


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker image build configuration to support flexible version management, allowing container images to be built with configurable component versions instead of fixed defaults.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/aqora-io/cli/pull/196?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->