### PR TITLE
fix: use lib notebook for default notebook for aqora.load

### DIFF
--- a/python/aqora/_aqora.pyi
+++ b/python/aqora/_aqora.pyi
@@ -35,5 +35,6 @@ class Client:
         slug: str,
         dest_dir: str | Path,
         notebook: str | None = None,
+        version: str | None = None,
         force: bool = False,
     ) -> str: ...

--- a/python/aqora/notebook.py
+++ b/python/aqora/notebook.py
@@ -47,11 +47,15 @@ def _notebook_cache_dir() -> Path:
     raise PermissionError("Could not find a writable site-packages cache directory")
 
 
-def _module_name(owner: str, slug: str, filename: str) -> str:
+def _module_name(owner: str, slug: str, filename: str, version: str | None = None) -> str:
     safe_owner = "".join(c if c.isalnum() or c == "_" else "_" for c in owner)
     safe_slug = "".join(c if c.isalnum() or c == "_" else "_" for c in slug)
     safe_file = "".join(c if c.isalnum() or c == "_" else "_" for c in Path(filename).stem)
-    return f"aqora_workspace_{safe_owner}_{safe_slug}_{safe_file}"
+    name = f"aqora_workspace_{safe_owner}_{safe_slug}_{safe_file}"
+    if version is not None:
+        safe_version = "".join(c if c.isalnum() or c == "_" else "_" for c in version)
+        name = f"{name}_v{safe_version}"
+    return name
 
 
 def _path_part(value: str) -> str:
@@ -63,30 +67,35 @@ async def _notebook_async(
     workspace: str,
     *,
     filename: str | None = None,
+    version: str | None = None,
     aqora_url: str | None = None,
     aqora_auth: bool = True,
     force_download: bool = False,
 ) -> ModuleType:
     owner, slug = _parse_workspace_slug(workspace)
     dest_dir = _notebook_cache_dir() / _path_part(owner) / _path_part(slug)
+    if version is not None:
+        dest_dir = dest_dir / _path_part(version)
 
     if filename and not force_download:
         notebook_path = dest_dir / filename
         if notebook_path.exists():
-            return _load_module(owner, slug, filename, notebook_path)
+            return _load_module(owner, slug, filename, notebook_path, version)
 
     client = Client(aqora_url)
     if aqora_auth and not client.authenticated:
         await client.authenticate()
     actual_filename = await client._download_workspace_notebook(
-        owner, slug, str(dest_dir), filename, force_download
+        owner, slug, str(dest_dir), filename, version, force_download
     )
     notebook_path = dest_dir / actual_filename
-    return _load_module(owner, slug, actual_filename, notebook_path)
+    return _load_module(owner, slug, actual_filename, notebook_path, version)
 
 
-def _load_module(owner: str, slug: str, filename: str, path: Path) -> ModuleType:
-    module_name = _module_name(owner, slug, filename)
+def _load_module(
+    owner: str, slug: str, filename: str, path: Path, version: str | None = None
+) -> ModuleType:
+    module_name = _module_name(owner, slug, filename, version)
     spec = importlib.util.spec_from_file_location(module_name, path)
     if spec is None or spec.loader is None:
         raise ImportError(f"Could not create module spec for '{path}'")
@@ -100,6 +109,7 @@ def load(
     workspace: str,
     *,
     filename: str | None = None,
+    version: str | None = None,
     aqora_url: str | None = None,
     aqora_auth: bool = True,
     force_download: bool = False,
@@ -107,6 +117,7 @@ def load(
     coro = _notebook_async(
         workspace,
         filename=filename,
+        version=version,
         aqora_url=aqora_url,
         aqora_auth=aqora_auth,
         force_download=force_download,

--- a/schema.graphql
+++ b/schema.graphql
@@ -263,6 +263,54 @@ enum ArchiveKind {
 	ZIP
 }
 
+type AudienceGroup {
+	label: String!
+	position: Int!
+	id: ID!
+	items: [AudienceGroupItem!]!
+}
+
+type AudienceGroupConnection {
+	"""
+	Information to aid in pagination.
+	"""
+	pageInfo: PageInfo!
+	"""
+	A list of edges.
+	"""
+	edges: [AudienceGroupEdge!]!
+	"""
+	A list of nodes.
+	"""
+	nodes: [AudienceGroup!]!
+	totalCount: Int!
+}
+
+"""
+An edge in a connection.
+"""
+type AudienceGroupEdge {
+	"""
+	The item at the end of the edge
+	"""
+	node: AudienceGroup!
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
+}
+
+input AudienceGroupInput {
+	label: String!
+	position: Int!
+	items: [String!]!
+}
+
+type AudienceGroupItem {
+	label: String!
+	id: ID!
+}
+
 enum Badge {
 	TEST
 	"""
@@ -987,6 +1035,10 @@ input CreateAnnouncementInput {
 	expiresAt: NaiveDate!
 }
 
+input CreateAudienceGroupsInput {
+	groups: [AudienceGroupInput!]!
+}
+
 input CreateBlogArticleInput {
 	title: String!
 	content: String!
@@ -1038,6 +1090,10 @@ input CreateCompetitionInput {
 	privateApprovals: Boolean! = true
 	timeline: CreateTimelineInput
 	rewards: [RewardInput!]
+	about: String
+	purpose: String
+	gettingStarted: String
+	audience: CreateAudienceGroupsInput
 }
 
 input CreateCompetitionStageInput {
@@ -1099,6 +1155,10 @@ input CreateEventInput {
 	tags: [String!]!
 	rewards: [RewardInput!]
 	timeline: CreateTimelineInput
+	about: String
+	purpose: String
+	gettingStarted: String
+	audience: CreateAudienceGroupsInput
 }
 
 input CreateForumInput {
@@ -1157,7 +1217,11 @@ input CreateTopicInput {
 }
 
 input CreateWorkspaceInput {
-	fromWorkspaceId: UUID
+	"""
+	The workspace version to clone the new workspace's first draft from;
+	seeds from the README template when omitted.
+	"""
+	fromVersionId: ID
 	name: String!
 	private: Boolean!
 	shortDescription: String
@@ -1656,6 +1720,7 @@ type Event implements ForumOwner & Node & Taggable & Rewardable {
 	invite: EventPublicInvite!
 	tags(after: String, before: String, first: Int, last: Int): TaggableConnection!
 	rewards(after: String, before: String, first: Int, last: Int): RewardConnection!
+	audienceGroups(before: String, after: String, first: Int, last: Int): AudienceGroupConnection!
 }
 
 type EventCompetition implements Node {
@@ -3422,6 +3487,10 @@ input UpdateAgendaInput {
 	agenda: JSON
 }
 
+input UpdateAudienceGroupsInput {
+	groups: [AudienceGroupInput!]!
+}
+
 input UpdateBlogArticleInput {
 	title: String
 	shortDescription: String
@@ -3475,6 +3544,10 @@ input UpdateCompetitionInput {
 	scoringCriteria: [UpdateCompetitionScoringCriterionInput!]
 	timeline: UpdateTimelineInput
 	rewards: [RewardInput!]
+	about: String
+	purpose: String
+	gettingStarted: String
+	audience: UpdateAudienceGroupsInput
 }
 
 input UpdateCompetitionMemberInput {
@@ -3551,6 +3624,10 @@ input UpdateEventInput {
 	tags: [String!]
 	rewards: [RewardInput!]
 	timeline: UpdateTimelineInput
+	about: String
+	purpose: String
+	gettingStarted: String
+	audience: UpdateAudienceGroupsInput
 }
 
 input UpdateForumInput {
@@ -3635,7 +3712,20 @@ input UpdateWorkspaceInput {
 }
 
 input UpdateWorkspaceVersionInput {
-	version: Semver!
+	"""
+	Rename the version's SemVer (drafts only). Omit to leave it unchanged.
+	"""
+	version: Semver
+	"""
+	Override the overview notebook for this version; null clears it (revert to
+	auto-detection), undefined leaves it unchanged.
+	"""
+	overviewNotebook: String
+	"""
+	Override the lib notebook for this version; null clears it, undefined
+	leaves it unchanged.
+	"""
+	libNotebook: String
 }
 
 scalar Upload
@@ -3844,8 +3934,8 @@ type Workspace implements Votable & ForumOwner & Node & Taggable {
 	voterCount: Int!
 	voters(after: String, before: String, first: Int, last: Int): VotersConnection!
 	tags(after: String, before: String, first: Int, last: Int): TaggableConnection!
-	entries: [WorkspaceEntry!]
-	defaultNotebook: String
+	overviewNotebook: String
+	libNotebook: String
 	versions(after: String, before: String, first: Int, last: Int, filters: WorkspaceVersionQueryFilters): WorkspaceVersionConnection!
 	version(version: Semver!): WorkspaceVersion
 	latestVersion: WorkspaceVersion
@@ -3916,6 +4006,11 @@ type WorkspaceFile implements WorkspaceEntry {
 	created: DateTime
 	modified: DateTime
 	size: Int
+	"""
+	Whether this file is a marimo notebook (carries marimo metadata),
+	so clients can render it as a live app view instead of source.
+	"""
+	isNotebook: Boolean!
 	downloadUrl: Url
 }
 
@@ -3999,6 +4094,22 @@ type WorkspaceVersion implements Node {
 	have no renderer.
 	"""
 	renderer: WorkspaceRunner
+	"""
+	Browse this version's indexed files. The version's storage is a kubimo
+	`WorkspaceDir` CR named after the version id; the root is batched through
+	the loader, nested directories are looked up by their `spec.path`.
+	"""
+	entries(path: String): [WorkspaceEntry!]
+	"""
+	The version's overview notebook: this version's override if set, else the
+	auto-detected default from this version's own files.
+	"""
+	overviewNotebook: String
+	"""
+	The version's lib notebook: this version's override if set, else a marimo
+	`lib.py` from this version's files, else the overview notebook.
+	"""
+	libNotebook: String
 }
 
 type WorkspaceVersionConnection {

--- a/src/graphql/get_workspace_version_notebook_download_url.graphql
+++ b/src/graphql/get_workspace_version_notebook_download_url.graphql
@@ -1,6 +1,6 @@
-query GetWorkspaceNotebookDownloadUrl($owner: String!, $slug: String!) {
+query GetWorkspaceVersionNotebookDownloadUrl($owner: String!, $slug: String!, $version: Semver!) {
   workspaceBySlug(owner: $owner, slug: $slug) {
-    latestVersion {
+    version(version: $version) {
       libNotebook
       entries {
         __typename

--- a/src/python_module.rs
+++ b/src/python_module.rs
@@ -228,7 +228,7 @@ impl PyClient {
         })
     }
 
-    #[pyo3(signature = (owner, slug, dest_dir, notebook=None, force=false))]
+    #[pyo3(signature = (owner, slug, dest_dir, notebook=None, version=None, force=false))]
     fn _download_workspace_notebook<'py>(
         &self,
         py: Python<'py>,
@@ -236,6 +236,7 @@ impl PyClient {
         slug: &str,
         dest_dir: std::path::PathBuf,
         notebook: Option<String>,
+        version: Option<String>,
         force: bool,
     ) -> PyResult<Bound<'py, PyAny>> {
         let inner = Arc::clone(&self.inner);
@@ -243,10 +244,11 @@ impl PyClient {
         let slug = slug.to_owned();
         future_into_py(py, async move {
             let client = inner.read().await.client.clone();
-            let filename =
-                download_workspace_notebook(client, owner, slug, dest_dir, notebook, force)
-                    .await
-                    .map_err(|error| ClientError::new_err((error.message(),)))?;
+            let filename = download_workspace_notebook(
+                client, owner, slug, dest_dir, notebook, version, force,
+            )
+            .await
+            .map_err(|error| ClientError::new_err((error.message(),)))?;
             Ok(filename)
         })
     }

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -1,4 +1,5 @@
 use crate::error::{self, Result};
+use crate::graphql_client::custom_scalars::Semver;
 use graphql_client::GraphQLQuery;
 use std::path::Path;
 use tokio::io::AsyncWriteExt;
@@ -12,29 +13,114 @@ use url::Url;
 )]
 pub struct GetWorkspaceNotebookDownloadUrl;
 
+#[derive(GraphQLQuery)]
+#[graphql(
+    query_path = "src/graphql/get_workspace_version_notebook_download_url.graphql",
+    schema_path = "schema.graphql",
+    response_derives = "Debug"
+)]
+pub struct GetWorkspaceVersionNotebookDownloadUrl;
+
+/// A workspace version's notebook metadata, normalized across the "latest
+/// version" and "specific version" queries so the download logic is shared.
+struct NotebookVersion {
+    lib_notebook: Option<String>,
+    files: Vec<(String, Option<Url>)>,
+}
+
+/// Fetches the notebook metadata for the requested version, or the latest
+/// published version when `version` is `None`.
+async fn fetch_notebook_version(
+    client: &aqora_client::Client,
+    owner: &str,
+    slug: &str,
+    version: Option<String>,
+) -> Result<NotebookVersion> {
+    let workspace_not_found = || {
+        error::user(
+            &format!("Workspace '{owner}/{slug}' not found"),
+            "Please make sure the owner and slug are correct",
+        )
+    };
+
+    if let Some(version) = version {
+        use get_workspace_version_notebook_download_url::*;
+        let selected = client
+            .send::<GetWorkspaceVersionNotebookDownloadUrl>(Variables {
+                owner: owner.to_owned(),
+                slug: slug.to_owned(),
+                version: version.clone(),
+            })
+            .await?
+            .workspace_by_slug
+            .ok_or_else(workspace_not_found)?
+            .version
+            .ok_or_else(|| {
+                error::user(
+                    &format!("Workspace '{owner}/{slug}' has no version '{version}'"),
+                    "Please make sure the version exists and is published",
+                )
+            })?;
+        Ok(NotebookVersion {
+            lib_notebook: selected.lib_notebook,
+            files: selected
+                .entries
+                .unwrap_or_default()
+                .into_iter()
+                .filter_map(|entry| match entry {
+                    GetWorkspaceVersionNotebookDownloadUrlWorkspaceBySlugVersionEntries::WorkspaceFile(file) => {
+                        Some((file.name, file.download_url))
+                    }
+                    _ => None,
+                })
+                .collect(),
+        })
+    } else {
+        use get_workspace_notebook_download_url::*;
+        let latest = client
+            .send::<GetWorkspaceNotebookDownloadUrl>(Variables {
+                owner: owner.to_owned(),
+                slug: slug.to_owned(),
+            })
+            .await?
+            .workspace_by_slug
+            .ok_or_else(workspace_not_found)?
+            .latest_version
+            .ok_or_else(|| {
+                error::user(
+                    &format!("Workspace '{owner}/{slug}' has no published version"),
+                    "Please make sure the workspace has a published version",
+                )
+            })?;
+        Ok(NotebookVersion {
+            lib_notebook: latest.lib_notebook,
+            files: latest
+                .entries
+                .unwrap_or_default()
+                .into_iter()
+                .filter_map(|entry| match entry {
+                    GetWorkspaceNotebookDownloadUrlWorkspaceBySlugLatestVersionEntries::WorkspaceFile(file) => {
+                        Some((file.name, file.download_url))
+                    }
+                    _ => None,
+                })
+                .collect(),
+        })
+    }
+}
+
 pub async fn download_workspace_notebook(
     client: aqora_client::Client,
     owner: String,
     slug: String,
     dest_dir: impl AsRef<Path>,
     notebook: Option<String>,
+    version: Option<String>,
     force: bool,
 ) -> Result<String> {
-    let workspace = client
-        .send::<GetWorkspaceNotebookDownloadUrl>(get_workspace_notebook_download_url::Variables {
-            owner: owner.clone(),
-            slug: slug.clone(),
-        })
-        .await?
-        .workspace_by_slug
-        .ok_or_else(|| {
-            error::user(
-                &format!("Workspace '{owner}/{slug}' not found"),
-                "Please make sure the owner and slug are correct",
-            )
-        })?;
+    let selected = fetch_notebook_version(&client, &owner, &slug, version).await?;
 
-    let notebook_name = notebook.or(workspace.default_notebook).ok_or_else(|| {
+    let notebook_name = notebook.or(selected.lib_notebook).ok_or_else(|| {
         error::user(
             &format!(
                 "No notebook specified and workspace '{owner}/{slug}' has no default notebook"
@@ -49,16 +135,10 @@ pub async fn download_workspace_notebook(
         return Ok(notebook_name);
     }
 
-    let download_url = workspace
-        .entries
-        .unwrap_or_default()
+    let download_url = selected
+        .files
         .into_iter()
-        .find_map(|entry| match entry {
-            get_workspace_notebook_download_url::GetWorkspaceNotebookDownloadUrlWorkspaceBySlugEntries::WorkspaceFile(
-                file,
-            ) if file.name == notebook_name => file.download_url,
-            _ => None,
-        })
+        .find_map(|(name, download_url)| (name == notebook_name).then_some(download_url).flatten())
         .ok_or_else(|| {
             error::user(
                 &format!("File '{notebook_name}' not found in workspace '{owner}/{slug}'"),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added audience-group targeting for events and competitions, including bulk creation and updates.
  * Workspaces now support separate overview and library notebooks, plus notebook-file identification.
  * Workspace notebook download/load can target a specific workspace version.
* **Breaking Changes**
  * Workspace cloning now uses a version-based selector (`fromVersionId` instead of `fromWorkspaceId`).
  * Workspace version updates now allow optional semver, and notebook fields have been reshaped (e.g., prior entries/default notebook fields removed).
* **Bug Fixes**
  * Notebook downloads now use the correct library-notebook fallback when no notebook is specified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->