### PR TITLE
feat: add AqoraCatalog for reading data catalogs via Iceberg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /target
 .env*
 .venv
+uv.lock
 dist
 __pycache__/
 *.so

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = ["typing-extensions>=4.13.2", "uv >=0.3.2, <1.0.0"]
 
 [project.entry-points."fsspec.specs"]
 aqora = "aqora.fsspec.AqoraFileSystem"
+aqora-iceberg = "aqora.iceberg_fs.AqoraIcebergFileSystem"
 
 [project.optional-dependencies]
 venv = [
@@ -33,6 +34,12 @@ pyarrow = ["fsspec>=2025.3.0", "pyarrow>=17.0.0"]
 qiskit = ["qio>=0.2.2", "qiskit>=2.3.1"]
 pytket = ["pytket>=1.30"]
 guppy = ["guppylang>=0.21"]
+iceberg = [
+  "fsspec[http]>=2025.3.0",
+  # 0.11.0 is the first release defining `pyiceberg.catalog.rest.auth`
+  # `AUTH_MANAGER`, which `aqora.iceberg` imports.
+  "pyiceberg>=0.11.0",
+]
 
 [project.urls]
 Repository = "https://github.com/aqora-io/cli"

--- a/python/aqora/fsspec.py
+++ b/python/aqora/fsspec.py
@@ -86,6 +86,8 @@ class _Cat(TypedDict):
 
 
 class AqoraFileSystem(AsyncFileSystem):
+    protocol = "aqora"
+
     _client: Client
     _need_auth: bool
 

--- a/python/aqora/iceberg.py
+++ b/python/aqora/iceberg.py
@@ -1,0 +1,173 @@
+# pyright: reportMissingTypeStubs=false
+
+import os
+import shutil
+import subprocess
+import threading
+import time
+from typing_extensions import Any, override
+
+from pyiceberg.catalog.rest import RestCatalog
+from pyiceberg.catalog.rest.auth import AUTH_MANAGER, AuthManager
+from pyiceberg.io.fsspec import FsspecFileIO
+from pyiceberg.typedef import Properties
+
+
+DEFAULT_AQORA_URL = "https://aqora.io"
+DEFAULT_TOKEN_TTL_SEC = 5 * 60.0
+DEFAULT_FETCH_TIMEOUT_SEC = 30.0
+
+
+def _resolve_aqora_url(explicit: str | None) -> str:
+    if explicit is not None:
+        return explicit
+    return os.environ.get("AQORA_URL", DEFAULT_AQORA_URL)
+
+
+def _split_path(path: str) -> tuple[str, str]:
+    parts = path.strip("/").split("/")
+    if len(parts) != 2 or not all(parts):
+        raise ValueError(
+            f"Expected `<owner>/<slug>` data catalog identifier, got: {path!r}"
+        )
+    return parts[0], parts[1]
+
+
+class AqoraAuthManager(AuthManager):
+    """Auth manager that obtains aqora access tokens via `aqora auth token`.
+
+    The CLI handles credential storage and refresh internally; this manager
+    simply re-invokes it after `ttl_seconds` to pick up rotated tokens.
+    """
+
+    def __init__(
+        self,
+        aqora_url: str | None = None,
+        ttl_seconds: float = DEFAULT_TOKEN_TTL_SEC,
+        timeout_seconds: float = DEFAULT_FETCH_TIMEOUT_SEC,
+        executable: str | None = None,
+    ) -> None:
+        self._aqora_url = aqora_url
+        self._ttl_seconds = float(ttl_seconds)
+        self._timeout_seconds = float(timeout_seconds)
+        self._executable = executable or shutil.which("aqora") or "aqora"
+        self._token: str | None = None
+        self._expires_at: float = 0.0
+        self._lock = threading.Lock()
+
+    def _fetch_token(self) -> str:
+        cmd: list[str] = [self._executable]
+        if self._aqora_url is not None:
+            cmd.extend(["--url", self._aqora_url])
+        cmd.extend(["auth", "token"])
+        try:
+            result = subprocess.run(
+                cmd,
+                check=True,
+                capture_output=True,
+                text=True,
+                timeout=self._timeout_seconds,
+            )
+        except FileNotFoundError as exc:
+            raise RuntimeError(
+                f"Could not run {self._executable!r}; install the aqora CLI to use AqoraCatalog"
+            ) from exc
+        except subprocess.TimeoutExpired as exc:
+            raise RuntimeError(
+                f"`aqora auth token` timed out after {self._timeout_seconds}s"
+            ) from exc
+        except subprocess.CalledProcessError as exc:
+            detail = (exc.stderr or exc.stdout or "").strip()
+            raise RuntimeError(
+                f"`aqora auth token` failed: {detail}" if detail else "`aqora auth token` failed"
+            ) from exc
+
+        token = result.stdout.strip()
+        if not token:
+            raise RuntimeError("`aqora auth token` returned an empty token")
+        return token
+
+    @override
+    def auth_header(self) -> str:
+        with self._lock:
+            if self._token is None or time.monotonic() >= self._expires_at:
+                self._token = self._fetch_token()
+                self._expires_at = time.monotonic() + self._ttl_seconds
+            return f"Bearer {self._token}"
+
+
+def _build_aqora_fs(properties: Properties) -> Any:
+    from .fsspec import AqoraFileSystem
+
+    return AqoraFileSystem(aqora_url=properties.get("aqora_url"))
+
+
+def _build_aqora_iceberg_fs(properties: Properties) -> Any:
+    from .iceberg_fs import AqoraIcebergFileSystem
+
+    raw_auth = properties.get(AUTH_MANAGER)
+    auth_manager = raw_auth if isinstance(raw_auth, AqoraAuthManager) else None
+    return AqoraIcebergFileSystem(
+        aqora_url=properties.get("aqora_url"),
+        auth_manager=auth_manager,
+    )
+
+
+class AqoraFsspecFileIO(FsspecFileIO):
+    """`FsspecFileIO` that recognises the `aqora://` and `aqora-iceberg://` schemes.
+
+    PyIceberg's stock `FsspecFileIO` keeps its own `SCHEME_TO_FS` dict and never
+    consults fsspec's global registry, so registering the schemes via
+    `fsspec.register_implementation` alone is not enough — we need to inject our
+    builders into this instance's dict.
+    """
+
+    def __init__(self, properties: Properties) -> None:
+        super().__init__(properties)
+        self._scheme_to_fs["aqora"] = _build_aqora_fs
+        self._scheme_to_fs["aqora-iceberg"] = _build_aqora_iceberg_fs
+
+
+class AqoraCatalog(RestCatalog):
+    """Iceberg REST catalog for an aqora data catalog identified by `<owner>/<slug>`.
+
+    Authenticates via `AqoraAuthManager`, which delegates to the `aqora auth token`
+    CLI subcommand for token retrieval and refresh. Reads manifest and data files
+    through `AqoraFsspecFileIO`, which routes `aqora-iceberg://` (manifest metadata)
+    and `aqora://` (parquet partitions) through the matching fsspec implementations.
+    """
+
+    def __init__(
+        self,
+        path: str,
+        *,
+        name: str | None = None,
+        aqora_url: str | None = None,
+        **properties: Any,
+    ) -> None:
+        owner, slug = _split_path(path)
+        url = _resolve_aqora_url(aqora_url).rstrip("/")
+        prefix = f"{owner}/{slug}"
+        merged: dict[str, Any] = {
+            "uri": f"{url}/data-catalog",
+            "prefix": prefix,
+            "py-io-impl": "aqora.iceberg.AqoraFsspecFileIO",
+            "aqora_url": url,
+            "auth": {
+                "type": "custom",
+                "impl": "aqora.iceberg.AqoraAuthManager",
+                "custom": {"aqora_url": url},
+            },
+        }
+        merged.update(properties)
+        super().__init__(name or f"aqora:{prefix}", **merged)
+
+    @override
+    def url(self, endpoint: str, prefixed: bool = True, **kwargs: Any) -> str:
+        # The aqora data-catalog REST API is per-catalog: every endpoint —
+        # including `/config` — lives under `/v1/{prefix}/...`, so always
+        # apply the prefix when building URLs.
+        return super().url(endpoint, prefixed=True, **kwargs)
+
+
+__all__ = ["AqoraCatalog", "AqoraAuthManager", "AqoraFsspecFileIO"]

--- a/python/aqora/iceberg_fs.py
+++ b/python/aqora/iceberg_fs.py
@@ -1,0 +1,141 @@
+# pyright: reportMissingTypeStubs=false
+
+import asyncio
+
+from typing_extensions import Any, override
+
+from fsspec.asyn import AsyncFileSystem
+from fsspec.implementations.http import HTTPFileSystem
+
+from .iceberg import AqoraAuthManager, _resolve_aqora_url
+
+
+REDIRECT_STATUSES = {301, 302, 303, 307, 308}
+
+
+class AqoraIcebergFileSystem(AsyncFileSystem):
+    """fsspec impl for `aqora-iceberg://{owner}/{slug}/{dataset_id}/{filename}`.
+
+    The data-catalog REST service emits these URIs as `manifest_list` /
+    `manifest_path` inside Iceberg metadata. We translate them to
+    `{aqora_url}/data-catalog/v1/{owner}/{slug}/iceberg-meta/{dataset_id}/{filename}`,
+    send a Bearer-authenticated request, and *manually* follow the redirect so
+    we can drop the Authorization header before hitting the S3 presigned URL.
+    Forwarding it triggers `SignatureDoesNotMatch` on S3/MinIO.
+    """
+
+    protocol = "aqora-iceberg"
+
+    def __init__(
+        self,
+        *args: Any,
+        aqora_url: str | None = None,
+        auth_manager: AqoraAuthManager | None = None,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self._aqora_url = _resolve_aqora_url(aqora_url).rstrip("/")
+        self._auth = auth_manager or AqoraAuthManager(self._aqora_url)
+        # Every request below goes through `self._http.set_session()` rather
+        # than `get_client()`: the latter mints a fresh `aiohttp.ClientSession`
+        # per call and never closes it, so a scan leaked two sessions per file.
+        # `set_session` caches one session and, when not asynchronous, registers
+        # a finalizer to close it.
+        self._http = HTTPFileSystem(asynchronous=self.asynchronous, loop=self._loop)
+
+    def _to_rest_url(self, path: str) -> str:
+        parts = path.lstrip("/").split("/")
+        if len(parts) != 4:
+            raise ValueError(
+                f"Expected aqora-iceberg path `<owner>/<slug>/<dataset-id>/<filename>`, got: {path!r}"
+            )
+        owner, slug, dataset_id, filename = parts
+        return f"{self._aqora_url}/data-catalog/v1/{owner}/{slug}/iceberg-meta/{dataset_id}/{filename}"
+
+    @staticmethod
+    def _range_header(start: int | None, end: int | None) -> str | None:
+        if start is None and end is None:
+            return None
+        lo = start or 0
+        hi = "" if end is None else str(end - 1)
+        return f"bytes={lo}-{hi}"
+
+    async def _resolve_signed_url(self, url: str) -> str:
+        """Hit our REST endpoint with Bearer, return the Location of the 302."""
+        session = await self._http.set_session()
+        # `auth_header()` shells out to `aqora auth token` on a cache miss.
+        # Running that inline would block the fsspec IO loop — and every other
+        # file read sharing it — for the duration of the subprocess.
+        auth_header = await asyncio.to_thread(self._auth.auth_header)
+        async with session.get(
+            url,
+            headers={"Authorization": auth_header},
+            allow_redirects=False,
+        ) as resp:
+            if resp.status in REDIRECT_STATUSES:
+                location = resp.headers.get("Location")
+                if not location:
+                    raise IOError(f"redirect from {url} missing Location header")
+                return location
+            # Server didn't redirect — surface the body as-is.
+            resp.raise_for_status()
+            raise IOError(
+                f"expected redirect from {url}, got HTTP {resp.status}"
+            )
+
+    @override
+    async def _cat_file(
+        self,
+        path: str,
+        start: int | None = None,
+        end: int | None = None,
+        **kwargs: Any,
+    ) -> bytes:
+        signed_url = await self._resolve_signed_url(self._to_rest_url(path))
+
+        s3_headers: dict[str, str] = {}
+        range_header = self._range_header(start, end)
+        if range_header:
+            s3_headers["Range"] = range_header
+
+        session = await self._http.set_session()
+        async with session.get(signed_url, headers=s3_headers) as resp:
+            resp.raise_for_status()
+            return await resp.read()
+
+    @override
+    async def _info(self, path: str, **kwargs: Any) -> dict[str, Any]:
+        signed_url = await self._resolve_signed_url(self._to_rest_url(path))
+
+        # Use a ranged GET rather than HEAD: the presigned URL is signed for
+        # GetObject, so HEAD comes back as 403 SignatureDoesNotMatch on
+        # MinIO/S3. `bytes=0-0` returns 206 with `Content-Range: bytes 0-0/SIZE`,
+        # from which we parse the total size without downloading the body.
+        session = await self._http.set_session()
+        async with session.get(signed_url, headers={"Range": "bytes=0-0"}) as resp:
+            resp.raise_for_status()
+            if resp.status == 206:
+                content_range = resp.headers.get("Content-Range", "")
+                # Format: "bytes 0-0/12345"
+                if "/" in content_range:
+                    total = content_range.rsplit("/", 1)[1].strip()
+                    if total != "*":
+                        return {"name": path, "size": int(total), "type": "file"}
+                # On a 206 the Content-Length describes the single requested
+                # byte, not the object, so there is nothing safe to fall back
+                # to — guessing here would silently truncate every read.
+                raise IOError(
+                    f"ranged GET of {path!r} returned 206 with unusable "
+                    f"Content-Range: {content_range!r}"
+                )
+            # Server ignored the Range header (200), so Content-Length covers
+            # the full body.
+            content_length = resp.headers.get("Content-Length")
+            if content_length is None:
+                raise IOError(
+                    f"response for {path!r} has neither Content-Range nor Content-Length"
+                )
+            return {"name": path, "size": int(content_length), "type": "file"}
+
+
+__all__ = ["AqoraIcebergFileSystem"]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Apache Iceberg catalog integration for accessing datasets through Aqora.
  * Added support for `aqora://` and `aqora-iceberg://` filesystem protocols.
  * Enabled authenticated metadata and ranged data access, including redirected object storage downloads.
  * Added optional Iceberg dependencies for projects that need this functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->