### PR TITLE
feat(template): add a workspace scaffold and a hosted variant

### DIFF
--- a/template/assets/workspace/.gitignore.hbs
+++ b/template/assets/workspace/.gitignore.hbs
@@ -1,0 +1,18 @@
+# Python-generated files
+__pycache__/
+*.py[oc]
+build/
+dist/
+wheels/
+.pdm-build/
+*.egg-info
+
+# Virtual environments
+.venv
+
+# Marimo
+__marimo__/
+
+# aqora
+.aqora
+__aqora__/

--- a/template/assets/workspace/pyproject.toml.hbs
+++ b/template/assets/workspace/pyproject.toml.hbs
@@ -1,15 +1,8 @@
 [project]
-name = "{{ name }}"
+name = "{{ slug }}"
 version = "0.1.0"
 requires-python = ">={{ python_version }}"
-{{#if hosted}}
 dependencies = []
-{{else}}
-dependencies = [
-  "marimo[recommended,lsp]>={{ marimo_version }}",
-  "aqora[pyarrow]>={{ cli_version }}",
-]
-{{/if}}
 
 [dependency-groups]
 dev = [
@@ -25,11 +18,9 @@ dev = [
 [build-system]
 requires = ["pdm-backend"]
 build-backend = "pdm.backend"
-{{#if hosted}}
 
 [tool.marimo.venv]
-path = "{{ venv_path }}"
+path = "/home/me/venv"
 # marimo is already installed here; setting this true reinstalls it on every
 # kernel start. `uv add` works either way.
 writable = false
-{{/if}}

--- a/template/assets/workspace/readme.py.hbs
+++ b/template/assets/workspace/readme.py.hbs
@@ -1,0 +1,29 @@
+import marimo
+
+__generated_with = "{{ marimo_version }}"
+app = marimo.App(width="full", auto_download=["html", "markdown", "ipynb"])
+
+
+@app.cell
+def _():
+    import marimo as mo
+
+    return (mo,)
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    # {{ name }} v{{ version }}
+
+    This notebook has been successfully created and is ready for you to start working.
+    To learn how to edit and run it, check out the [marimo documentation](https://docs.marimo.io/guides/).
+
+    Whether you're analyzing data, testing algorithms, or exploring new ideas, this is your space.
+    Once you're done, don't forget to click the **Publish** button to share your work. Happy coding! 🚀
+    """)
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/template/src/dataset_marimo.rs
+++ b/template/src/dataset_marimo.rs
@@ -10,6 +10,9 @@ use crate::utils::{assert_semver, assert_slug, assert_username, OptionExt};
 const DEFAULT_PYTHON_VERSION: &str = "3.10";
 const DEFAULT_MARIMO_VERSION: &str = "0.23.4";
 const DEFAULT_CLI_VERSION_STR: &str = env!("CARGO_PKG_VERSION");
+/// Where the kubimo marimo image keeps a workspace's venv. Only used when
+/// `hosted` is set.
+const DEFAULT_VENV_PATH: &str = "/home/me/venv";
 
 #[derive(Builder, Serialize, Debug)]
 #[builder(build_fn(validate = "Self::validate"))]
@@ -30,6 +33,18 @@ pub struct DatasetMarimoTemplate {
     version: Option<String>,
     #[builder(setter(into, strip_option), default)]
     raw_init: Option<String>,
+    /// Scaffold for an image that already provides marimo and aqora in its
+    /// system interpreter, rather than for a user's own machine.
+    ///
+    /// Off by default: `aqora new dataset-marimo` runs locally, where nothing
+    /// else installs marimo, so the generated project must declare it. A hosted
+    /// workspace must not — a venv copy shadows the image's build and leaves
+    /// kernels on a different marimo from the server.
+    #[builder(default)]
+    hosted: bool,
+    /// Virtualenv path recorded under `[tool.marimo.venv]`, hosted only.
+    #[builder(setter(into), default = "DEFAULT_VENV_PATH.to_string()")]
+    venv_path: String,
 }
 
 impl DatasetMarimoTemplate {
@@ -66,5 +81,66 @@ impl DatasetMarimoTemplateBuilder {
         self.build()
             .map_err(|e| RenderErrorReason::Other(e.to_string()))?
             .render(out)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn render(hosted: bool) -> String {
+        let dir = tempfile::tempdir().unwrap();
+        let out = dir.path().join("ws");
+        DatasetMarimoTemplate::builder()
+            .name("my-dataset")
+            .owner("someone")
+            .local_slug("a-dataset")
+            .version("0.1.0")
+            .hosted(hosted)
+            .render(&out)
+            .expect("render");
+        std::fs::read_to_string(out.join("pyproject.toml")).unwrap()
+    }
+
+    /// `aqora new dataset-marimo` runs on a user's own machine, where nothing
+    /// else installs marimo. The generated project has to declare it, or the
+    /// workspace has no marimo at all.
+    #[test]
+    fn a_local_scaffold_declares_marimo_and_aqora() {
+        let pyproject = render(false);
+        assert!(pyproject.contains("marimo[recommended,lsp]"), "{pyproject}");
+        assert!(pyproject.contains("aqora[pyarrow]"), "{pyproject}");
+        // No venv table: the path is a kubimo image detail and would be wrong
+        // anywhere else.
+        assert!(!pyproject.contains("[tool.marimo.venv]"), "{pyproject}");
+    }
+
+    /// A hosted workspace inherits both from the image's system interpreter.
+    /// Declaring them installs shadowing copies into the venv — for marimo a
+    /// ~920MB duplicate that also splits the kernel from the server.
+    #[test]
+    fn a_hosted_scaffold_declares_neither() {
+        let pyproject = render(true);
+        let deps = pyproject
+            .split("dependencies = [")
+            .nth(1)
+            .and_then(|rest| rest.split(']').next())
+            .expect("dependencies array");
+        assert!(!deps.contains("marimo"), "{deps}");
+        assert!(!deps.contains("aqora"), "{deps}");
+        assert!(pyproject.contains("[tool.marimo.venv]"), "{pyproject}");
+        assert!(pyproject.contains("writable = false"), "{pyproject}");
+        assert!(pyproject.contains("/home/me/venv"), "{pyproject}");
+    }
+
+    /// Both variants must still be valid TOML — the `{{#if}}` blocks are easy
+    /// to get subtly wrong in a way that only shows up when uv parses it.
+    #[test]
+    fn both_variants_parse_as_toml() {
+        for hosted in [false, true] {
+            let pyproject = render(hosted);
+            toml::from_str::<toml::Value>(&pyproject)
+                .unwrap_or_else(|err| panic!("hosted={hosted}: {err}\n{pyproject}"));
+        }
     }
 }

--- a/template/src/lib.rs
+++ b/template/src/lib.rs
@@ -2,9 +2,11 @@ pub mod dataset_marimo;
 pub mod registry;
 pub mod use_case;
 pub mod utils;
+pub mod workspace;
 
 pub use handlebars;
 
 pub use dataset_marimo::DatasetMarimoTemplate;
 pub use handlebars::RenderError;
 pub use use_case::UseCaseTemplate;
+pub use workspace::WorkspaceTemplate;

--- a/template/src/utils.rs
+++ b/template/src/utils.rs
@@ -70,3 +70,26 @@ pub fn assert_no_control_chars(string: &str) -> Result<(), String> {
     }
     Ok(())
 }
+
+/// Rejects text that cannot be embedded in a Python raw triple-quoted string.
+///
+/// Free-text display names are interpolated into `mo.md(r"""…""")` in the generated
+/// `readme.py`, and the registry renders with `no_escape`, so the value reaches the file
+/// verbatim. A `"""` closes the literal early; a trailing backslash escapes the closing
+/// quote even in a raw string. Either produces a `readme.py` that is a Python syntax
+/// error — and since that is the workspace's landing notebook, the workspace would be
+/// born unopenable.
+pub fn assert_python_raw_string_safe(string: &str) -> Result<(), String> {
+    assert_no_control_chars(string)?;
+    if string.contains("\"\"\"") {
+        return Err(format!(
+            "String contains a triple quote, which would end the generated Python string: {string}"
+        ));
+    }
+    if string.ends_with('\\') {
+        return Err(format!(
+            "String ends with a backslash, which would escape the closing quote: {string}"
+        ));
+    }
+    Ok(())
+}

--- a/template/src/workspace.rs
+++ b/template/src/workspace.rs
@@ -1,0 +1,196 @@
+use std::path::Path;
+
+use derive_builder::Builder;
+use handlebars::{RenderError, RenderErrorReason};
+use serde::Serialize;
+
+use crate::registry::REGISTRY;
+use crate::utils::{assert_python_raw_string_safe, assert_semver, assert_slug};
+
+const DEFAULT_PYTHON_VERSION: &str = "3.10";
+const DEFAULT_MARIMO_VERSION: &str = "0.23.4";
+const DEFAULT_VERSION: &str = "0.0.0";
+
+/// The starter contents of a plain marimo workspace.
+///
+/// The dataset variant is [`crate::DatasetMarimoTemplate`]; this one has no
+/// dataset to wire up, so its notebook is just a welcome page. Both exist so
+/// that the two kinds of workspace are scaffolded the same way, from templates
+/// rather than from a shell heredoc built at the call site.
+#[derive(Builder, Serialize, Debug)]
+#[builder(build_fn(validate = "Self::validate"))]
+pub struct WorkspaceTemplate {
+    #[builder(setter(into), default = "DEFAULT_PYTHON_VERSION.to_string()")]
+    python_version: String,
+    #[builder(setter(into), default = "DEFAULT_MARIMO_VERSION.to_string()")]
+    marimo_version: String,
+    /// Display name, shown in the notebook's heading.
+    #[builder(setter(into))]
+    name: String,
+    /// Slug-safe identifier, used as the Python project name.
+    #[builder(setter(into))]
+    slug: String,
+    /// Workspace version, shown alongside the name.
+    #[builder(setter(into), default = "DEFAULT_VERSION.to_string()")]
+    version: String,
+}
+
+impl WorkspaceTemplate {
+    pub fn builder() -> WorkspaceTemplateBuilder {
+        WorkspaceTemplateBuilder::default()
+    }
+
+    pub fn render(&self, out: impl AsRef<Path>) -> Result<(), RenderError> {
+        REGISTRY.render_all("workspace", self, out)
+    }
+}
+
+impl WorkspaceTemplateBuilder {
+    pub fn validate(&self) -> Result<(), String> {
+        self.python_version
+            .as_deref()
+            .map(assert_semver)
+            .transpose()?;
+        self.marimo_version
+            .as_deref()
+            .map(assert_semver)
+            .transpose()?;
+        self.version.as_deref().map(assert_semver).transpose()?;
+        // The slug becomes the `[project] name` in pyproject.toml, so it is a slug.
+        assert_slug(self.slug.as_ref().ok_or("Slug is required")?)?;
+        // The display name stays free text, but "markdown" understates where it lands:
+        // it is markdown *inside a Python raw string literal* in readme.py, rendered
+        // without escaping. It has to be safe for the literal as well as legible.
+        let name = self.name.as_ref().ok_or("Name is required")?;
+        if name.trim().is_empty() {
+            return Err("Name must not be blank".to_string());
+        }
+        assert_python_raw_string_safe(name)?;
+        Ok(())
+    }
+
+    pub fn render(&self, out: impl AsRef<Path>) -> Result<(), RenderError> {
+        self.build()
+            .map_err(|e| RenderErrorReason::Other(e.to_string()))?
+            .render(out)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rendered() -> (tempfile::TempDir, std::path::PathBuf) {
+        let dir = tempfile::tempdir().unwrap();
+        let out = dir.path().join("workspace");
+        WorkspaceTemplate::builder()
+            .name("My Workspace")
+            .slug("my-workspace")
+            .render(&out)
+            .expect("render");
+        (dir, out)
+    }
+
+    #[test]
+    fn renders_the_three_starter_files() {
+        let (_dir, out) = rendered();
+        for file in ["readme.py", "pyproject.toml", ".gitignore"] {
+            assert!(out.join(file).is_file(), "missing {file}");
+        }
+    }
+
+    /// `readme.py` is not merely cosmetic: the platform picks it as a
+    /// workspace's default overview notebook by exact filename.
+    #[test]
+    fn the_notebook_carries_the_display_name_and_version() {
+        let (_dir, out) = rendered();
+        let readme = std::fs::read_to_string(out.join("readme.py")).unwrap();
+        assert!(readme.contains("# My Workspace v0.0.0"), "{readme}");
+        assert!(readme.contains("import marimo"));
+    }
+
+    /// Declaring marimo here would make `uv sync` install a second copy into
+    /// the venv, shadowing the image's system build — a ~920MB duplicate that
+    /// also leaves kernels on a different marimo from the server.
+    #[test]
+    fn the_pyproject_declares_neither_marimo_nor_aqora() {
+        let (_dir, out) = rendered();
+        let pyproject = std::fs::read_to_string(out.join("pyproject.toml")).unwrap();
+        let deps = pyproject
+            .split("dependencies = [")
+            .nth(1)
+            .and_then(|rest| rest.split(']').next())
+            .expect("dependencies array");
+        assert!(!deps.contains("marimo"), "{deps}");
+        assert!(!deps.contains("aqora"), "{deps}");
+        // And the venv table must be present, so the runner does not have to
+        // append it at startup — which would rewrite a tracked file on every
+        // boot and re-upload it.
+        assert!(pyproject.contains("[tool.marimo.venv]"), "{pyproject}");
+        assert!(pyproject.contains("writable = false"), "{pyproject}");
+    }
+
+    #[test]
+    fn the_project_name_is_the_slug_not_the_display_name() {
+        let (_dir, out) = rendered();
+        let pyproject = std::fs::read_to_string(out.join("pyproject.toml")).unwrap();
+        assert!(
+            pyproject.contains(r#"name = "my-workspace""#),
+            "{pyproject}"
+        );
+    }
+
+    #[test]
+    fn a_non_slug_identifier_is_refused() {
+        assert!(WorkspaceTemplate::builder()
+            .name("My Workspace")
+            .slug("Not A Slug")
+            .build()
+            .is_err());
+    }
+
+    /// The display name is rendered without escaping into `mo.md(r"""…""")`, so a name
+    /// that can close that literal produces a `readme.py` which is a Python syntax
+    /// error. `readme.py` is the workspace's default overview notebook, so the
+    /// workspace would be born unopenable — and the name comes from unvalidated user
+    /// input at the platform's GraphQL boundary.
+    #[test]
+    fn a_name_that_could_break_the_notebook_is_refused() {
+        for name in [
+            r#"Sneaky """) + __import__("os").system("id") + mo.md(r"""#,
+            r#"ends with a backslash \"#,
+            "carriage\rreturn",
+            "   ",
+            "",
+        ] {
+            assert!(
+                WorkspaceTemplate::builder()
+                    .name(name)
+                    .slug("my-workspace")
+                    .build()
+                    .is_err(),
+                "should have been refused: {name:?}"
+            );
+        }
+    }
+
+    /// Names people actually use must still work — the guard is narrow on purpose.
+    #[test]
+    fn ordinary_display_names_are_accepted() {
+        for name in [
+            "My Workspace",
+            "Ünïcodé — dashes, \"quotes\" & 'apostrophes'",
+            "back\\slash in the middle",
+            "100% coverage (v2)",
+        ] {
+            assert!(
+                WorkspaceTemplate::builder()
+                    .name(name)
+                    .slug("my-workspace")
+                    .build()
+                    .is_ok(),
+                "should have been accepted: {name:?}"
+            );
+        }
+    }
+}


### PR DESCRIPTION
A plain marimo workspace was scaffolded by a shell heredoc built at the call site in the platform, while dataset workspaces went through this crate. Adds a `workspace` asset set so both are templates, and so the notebook the platform hands new users lives next to the one it hands dataset users.

`dataset_marimo` gains a `hosted` flag, off by default. A hosted workspace runs on the kubimo marimo image, which installs marimo and aqora into the system interpreter and builds the venv with --system-site-packages, so the scaffold must not declare them: a venv copy shadows the image build, and for marimo that is a ~920MB duplicate that also leaves kernels running a different marimo from the server. `aqora new dataset-marimo` runs on a user own machine, where nothing else provides marimo, so the local scaffold must keep declaring it — hence a flag rather than a straight removal. Hosted scaffolds also carry [tool.marimo.venv], which the runner would otherwise append to a tracked pyproject.toml on every boot.

Tested both ways round, including that each variant is still valid TOML — the conditional blocks are easy to get subtly wrong in a way that only surfaces when uv parses the result.

Also validates the display name. It is interpolated without escaping into mo.md(r"""…""") in readme.py, so a name containing a triple quote closes that literal early and a trailing backslash escapes the closing quote — either way the generated readme.py is a Python syntax error, and since the platform picks readme.py as a workspace's default overview notebook, the workspace is born unopenable. The name reaches here from GraphQL CreateWorkspaceInput with no validation of its own.

The guard is deliberately narrow: control characters, a triple quote, a trailing backslash, and blank. Unicode, quotes, apostrophes, percent signs and interior backslashes all still render, with a test pinning that so the check does not quietly grow into slug validation. UseCaseTemplate already took this approach for its own free-text title.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added starter workspace generation for Marimo projects, including a runnable welcome app, project configuration, and standard ignore rules.
  * Added support for hosted workspaces with a configured, read-only virtual environment.
  * Added configurable project name, slug, Python version, Marimo version, and workspace version.
  * Added validation to prevent unsafe names or values from breaking generated files.

* **Bug Fixes**
  * Improved generated dependency configuration for hosted and local workspace setups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->